### PR TITLE
Fix bug with merging cats

### DIFF
--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -842,6 +842,10 @@ def _merge_approx_rcs(
         rc_old = rc_old.copy()
 
     mask = ~rc_new.isna()
+
+    if np.sum(mask) == 0:
+        return rc_old if not inplace else None
+
     old_cats = rc_old.cat.categories
     cats_to_add = (
         pd.CategoricalIndex(rc_new.loc[mask]).remove_unused_categories().categories

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -844,11 +844,10 @@ def _merge_approx_rcs(
     mask = ~rc_new.isna()
     old_cats = rc_old.cat.categories
     cats_to_add = (
-        pd.CategoricalIndex(rc_new[mask]).remove_unused_categories().categories
+        pd.CategoricalIndex(rc_new.loc[mask]).remove_unused_categories().categories
     )
 
     rc_old.cat.set_categories(old_cats | cats_to_add, inplace=True)
-    rc_new.cat.set_categories(old_cats | cats_to_add, inplace=True)
 
     rc_old.loc[mask] = rc_new.loc[mask]
 

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -848,6 +848,7 @@ def _merge_approx_rcs(
     )
 
     rc_old.cat.set_categories(old_cats | cats_to_add, inplace=True)
+    rc_new.cat.set_categories(old_cats | cats_to_add, inplace=True)
 
     rc_old.loc[mask] = rc_new.loc[mask]
 

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -852,6 +852,7 @@ def _merge_approx_rcs(
     )
 
     rc_old.cat.set_categories(old_cats | cats_to_add, inplace=True)
+    rc_new.cat.set_categories(old_cats | cats_to_add, inplace=True)
 
     rc_old.loc[mask] = rc_new.loc[mask]
 

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -847,6 +847,7 @@ def _merge_approx_rcs(
         return rc_old if not inplace else None
 
     old_cats = rc_old.cat.categories
+    new_cats = rc_new.cat.categories
     cats_to_add = (
         pd.CategoricalIndex(rc_new.loc[mask]).remove_unused_categories().categories
     )
@@ -855,5 +856,8 @@ def _merge_approx_rcs(
     rc_new.cat.set_categories(old_cats | cats_to_add, inplace=True)
 
     rc_old.loc[mask] = rc_new.loc[mask]
+    rc_old.cat.remove_unused_categories(inplace=True)
+
+    rc_new.cat.set_categories(new_cats, inplace=True)  # return to previous state
 
     return rc_old if not inplace else None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,3 +39,13 @@ class TestToolsUtils:
 
         assert _ is None
         np.testing.assert_array_equal(x.values, expected.values)
+
+    def test_merge_rcs_normal_run_completely_different_categories(self):
+        x = pd.Series(["a", "a", "a"]).astype("category")
+        y = pd.Series(["b", "b", "b"]).astype("category")
+        expected = pd.Series(["b", "b", "b"]).astype("category")
+
+        res = _merge_approx_rcs(x, y, inplace=False)
+
+        np.testing.assert_array_equal(res.values, expected.values)
+        np.testing.assert_array_equal(res.cat.categories.values, ["b"])


### PR DESCRIPTION
Hi @michalk8 , I had to add one line to get this to work, otherwise I got the following error:

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-54-480cface07f3> in <module>
      1 mask_bcs = list(adata_t[mask].obs_names[:40])
----> 2 mc_fwd.set_approx_rcs({cl: mask_bcs}, cluster_key='clusters', add_to_existing=True)

~/Projects/cellrank/cellrank/tools/_markov_chain.py in set_approx_rcs(self, rc_labels, cluster_key, en_cutoff, p_thresh, add_to_existing)
    612                 )
    613             rc_labels = _merge_approx_rcs(
--> 614                 self.approx_recurrent_classes, rc_labels, inplace=False
    615             )
    616 

~/Projects/cellrank/cellrank/tools/_utils.py in _merge_approx_rcs(rc_old, rc_new, inplace)
    850     rc_old.cat.set_categories(old_cats | cats_to_add, inplace=True)
    851 
--> 852     rc_old.loc[mask] = rc_new.loc[mask]
    853 
    854     return rc_old if not inplace else None

~/miniconda3/envs/cellrank/lib/python3.6/site-packages/pandas/core/indexing.py in __setitem__(self, key, value)
    669             key = com.apply_if_callable(key, self.obj)
    670         indexer = self._get_setitem_indexer(key)
--> 671         self._setitem_with_indexer(indexer, value)
    672 
    673     def _validate_key(self, key, axis: int):

~/miniconda3/envs/cellrank/lib/python3.6/site-packages/pandas/core/indexing.py in _setitem_with_indexer(self, indexer, value)
   1063             # actually do the set
   1064             self.obj._consolidate_inplace()
-> 1065             self.obj._data = self.obj._data.setitem(indexer=indexer, value=value)
   1066             self.obj._maybe_update_cacher(clear=True)
   1067 

~/miniconda3/envs/cellrank/lib/python3.6/site-packages/pandas/core/internals/managers.py in setitem(self, **kwargs)
    559 
    560     def setitem(self, **kwargs):
--> 561         return self.apply("setitem", **kwargs)
    562 
    563     def putmask(self, **kwargs):

~/miniconda3/envs/cellrank/lib/python3.6/site-packages/pandas/core/internals/managers.py in apply(self, f, filter, **kwargs)
    440                 applied = b.apply(f, **kwargs)
    441             else:
--> 442                 applied = getattr(b, f)(**kwargs)
    443             result_blocks = _extend_blocks(applied, result_blocks)
    444 

~/miniconda3/envs/cellrank/lib/python3.6/site-packages/pandas/core/internals/blocks.py in setitem(self, indexer, value)
   1795 
   1796         check_setitem_lengths(indexer, value, self.values)
-> 1797         self.values[indexer] = value
   1798         return self
   1799 

~/miniconda3/envs/cellrank/lib/python3.6/site-packages/pandas/core/arrays/categorical.py in __setitem__(self, key, value)
   2032             if not is_dtype_equal(self, value):
   2033                 raise ValueError(
-> 2034                     "Cannot set a Categorical with another, "
   2035                     "without identical categories"
   2036                 )

ValueError: Cannot set a Categorical with another, without identical categories

> /Users/marius/miniconda3/envs/cellrank/lib/python3.6/site-packages/pandas/core/arrays/categorical.py(2034)__setitem__()
   2032             if not is_dtype_equal(self, value):
   2033                 raise ValueError(
-> 2034                     "Cannot set a Categorical with another, "
   2035                     "without identical categories"
   2036                 )
```

If you think this finally resolves the bug, then feel free to merge. 