### PR TITLE
Root final improvements

### DIFF
--- a/cellrank/tools/_constants.py
+++ b/cellrank/tools/_constants.py
@@ -55,7 +55,7 @@ def _colors(k: Union[str, LinKey, RcKey]) -> str:
 
 
 def _probs(k: Union[str, RcKey]) -> str:
-    return f"{k}_cont"
+    return f"{k}_probs"
 
 
 def _dp(k: Union[str, LinKey]) -> str:

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -484,16 +484,20 @@ class GPCCA(BaseEstimator):
                 - :paramref:`diff_potential`
         """
 
-        kwargs["return_weights"] = False
         if names is None:
-            self._lin_probs = self._meta_lin_probs.copy()
-        elif redistribute:
-            self._lin_probs = self._meta_lin_probs[list(names) + [Lin.OTHERS]]
+            names = self._meta_lin_probs.names
+            redistribute = False
+
+        names = list(names)
+        kwargs["return_weights"] = False
+
+        if redistribute:
+            self._lin_probs = self._meta_lin_probs[names + [Lin.OTHERS]]
             self._lin_probs = self._lin_probs.reduce(
                 [" or ".join(_convert_lineage_name(name)) for name in names], **kwargs
             )
         else:
-            self._lin_probs = self._meta_lin_probs[list(names) + [Lin.REST]]
+            self._lin_probs = self._meta_lin_probs[names + [Lin.REST]]
 
         self._set_main_states(n_cells)
         self._dp = entropy(self._lin_probs.X.T)

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -31,7 +31,7 @@ import matplotlib.colors as mcolors
 
 class GPCCA(BaseEstimator):
     """
-    Generalized Perron Cluster Cluster Analysis [GPCCA18]_.
+    Generalized Perron Cluster Cluster Analysis [GPCCA18]/.
 
     Params
     ------
@@ -87,6 +87,7 @@ class GPCCA(BaseEstimator):
         self._meta_lin_probs = None
 
         self._main_states = None
+        self._main_states_probabilities = None
         self._n_cells = None  # serves as a cache for plotting
 
     def compute_eig(self, k: int = 20, which: str = "LR", alpha: float = 1) -> None:
@@ -1084,6 +1085,11 @@ class GPCCA(BaseEstimator):
         return self._coarse_stat_dist
 
     @property
-    def main_states(self) -> np.ndarray:
-        """Subset and/or combination of metstable states."""
+    def main_states(self) -> pd.Series:
+        """Subset and/or combination of main states."""
         return self._main_states
+
+    @property
+    def main_states_probabilities(self) -> pd.Series:
+        """Upper bound of of becoming a main states"""
+        return self._main_states_probabilities


### PR DESCRIPTION
Fixes #111  #122 , #117 
@Marius1311 I reluctantly did as you've suggested and opted NOT to save to `adata.obs` when plotting `n_cells!=None`. However, I think this might confusing for user, having `X` cells saved and `Y` cells not. The `saving` approach is on the other hand a bit redundant: `plot_main_states` with different that `n_cells` when calling `set_main_states` will be overwritten, making the previous choice useless.
One option would be instead of having `n_cells=...` have `plot_categorical={True,False}`, but this is clunky in a way that user has to call `set_main_states(...)` and then `plot_main_states(...)` to visualize different `#cells`.