### PR TITLE
Adapt CFLARE 

### DIFF
--- a/cellrank/tools/estimators/_base_estimator.py
+++ b/cellrank/tools/estimators/_base_estimator.py
@@ -266,10 +266,10 @@ class BaseEstimator(ABC):
         y_min_, y_max_ = adapt_range(y_min, y_max, final_range)
 
         # plot the data and the unit circle
-        ax.scatter(D.real, D.imag, marker=".", label="Eigenvalue")
+        ax.scatter(D.real, D.imag, marker=".", label="eigenvalue")
         t = np.linspace(0, 2 * np.pi, 500)
         x_circle, y_circle = np.sin(t), np.cos(t)
-        ax.plot(x_circle, y_circle, "k-", label="Unit circle")
+        ax.plot(x_circle, y_circle, "k-", label="unit circle")
 
         # set labels, ranges and legend
         ax.set_xlabel("Im($\lambda$)")
@@ -337,11 +337,11 @@ class BaseEstimator(ABC):
 
         # plot the top eigenvalues
         fig, ax = plt.subplots(nrows=1, ncols=1, dpi=dpi, figsize=figsize)
-        ax.scatter(ixs[mask], D_real[mask], marker="o", label="Real eigenvalue")
-        ax.scatter(ixs[~mask], D_real[~mask], marker="o", label="Complex eigenvalue")
+        ax.scatter(ixs[mask], D_real[mask], marker="o", label="real eigenvalue")
+        ax.scatter(ixs[~mask], D_real[~mask], marker="o", label="complex eigenvalue")
 
         # add dashed line for the eigengap, ticks, labels, title and legend
-        ax.axvline(self._eig["eigengap"], label="Eigengap", ls="--")
+        ax.axvline(self._eig["eigengap"], label="eigengap", ls="--")
 
         ax.set_xlabel("index")
         ax.set_xticks(range(len(D)))

--- a/cellrank/tools/estimators/_cflare.py
+++ b/cellrank/tools/estimators/_cflare.py
@@ -860,9 +860,13 @@ class CFLARE(BaseEstimator):
         c._lin_probs = copy(self.lineage_probabilities)
         c._dp = copy(self.diff_potential)
 
-        c._metastable_states = copy(self.metastable_states)
-        c._metastable_states_probs = copy(self.metastable_states_probabilities)
-        c._metastable_states_colors = copy(self._meta_states_colors)
+        # c._metastable_states = copy(self.metastable_states)
+        # c._metastable_states_probs = copy(self.metastable_states_probabilities)
+        # c._metastable_states_colors = copy(self._meta_states_colors)
+
+        c._meta_states = copy(self._meta_states)
+        c._meta_states_probs = copy(self._meta_states_probs)
+        c._meta_states_colors = copy(self._meta_states_colors)
 
         c._G2M_score = copy(self._G2M_score)
         c._S_score = copy(self._S_score)

--- a/cellrank/tools/estimators/_cflare.py
+++ b/cellrank/tools/estimators/_cflare.py
@@ -31,6 +31,8 @@ from cellrank.tools._utils import (
     partition,
 )
 
+EPS = np.finfo(np.float64).eps
+
 
 class CFLARE(BaseEstimator):
     """
@@ -295,6 +297,12 @@ class CFLARE(BaseEstimator):
         # set the direction and get the vectors
         side = "left" if left else "right"
         D, V = self._eig["D"], self._eig[f"V_{side[0]}"]
+
+        # if irreducible, first rigth e-vec should be const.
+        if side == "right":
+            # quick check for irreducibility:
+            if np.sum(np.isclose(D, 1, rtol=1e2 * EPS, atol=1e2 * EPS)) == 1:
+                V[:, 0] = 1.0
 
         if use is None:
             use = self._eig["eigengap"] + 1  # add one because first e-vec has index 0

--- a/cellrank/tools/estimators/_cflare.py
+++ b/cellrank/tools/estimators/_cflare.py
@@ -80,7 +80,7 @@ class CFLARE(BaseEstimator):
         self._rec_classes = None
         self._trans_classes = None
 
-        self._metastable_states, self._metastable_states_colors, self._metastable_states_probs = (
+        self._meta_states, self._meta_states_colors, self._meta_states_probs = (
             None,
             None,
             None,
@@ -107,14 +107,14 @@ class CFLARE(BaseEstimator):
             )
 
         if self._rc_key in self._adata.obs.keys():
-            self._metastable_states = self._adata.obs[self._rc_key]
+            self._meta_states = self._adata.obs[self._rc_key]
         else:
             logg.debug(
                 f"DEBUG: `{self._rc_key}` not found in `adata.obs`. Setting `.metastable_states` to `None`"
             )
 
         if _colors(self._rc_key) in self._adata.uns.keys():
-            self._metastable_states_colors = self._adata.uns[_colors(self._rc_key)]
+            self._meta_states_colors = self._adata.uns[_colors(self._rc_key)]
         else:
             logg.debug(
                 f"DEBUG: `{_colors(self._rc_key)}` not found in `adata.uns`. "
@@ -157,7 +157,7 @@ class CFLARE(BaseEstimator):
             )
 
         if _probs(self._rc_key) in self._adata.obs.keys():
-            self._metastable_states_probs = self._adata.obs[_probs(self._rc_key)]
+            self._meta_states_probs = self._adata.obs[_probs(self._rc_key)]
         else:
             logg.debug(
                 f"DEBUG: `{_probs(self._rc_key)}` not found in `adata.obs`. "
@@ -479,7 +479,7 @@ class CFLARE(BaseEstimator):
         # compute a rc probability
         logg.debug("DEBUG: Computing probabilities of approximate recurrent classes")
         probs = self._compute_metastable_states_prob(use)
-        self._metastable_states_probs = probs
+        self._meta_states_probs = probs
         self._adata.obs[_probs(self._rc_key)] = probs
 
         # retrieve embedding and concatenate
@@ -576,26 +576,26 @@ class CFLARE(BaseEstimator):
             Nothing, just plots the approximate recurrent classes.
         """
 
-        if self._metastable_states is None:
+        if self._meta_states is None:
             raise RuntimeError(
                 "Compute approximate recurrent classes first as `.compute_metastable_states()`"
             )
 
-        self._adata.obs[self._rc_key] = self._metastable_states
+        self._adata.obs[self._rc_key] = self._meta_states
 
         # check whether the length of the color array matches the number of clusters
         color_key = _colors(self._rc_key)
         if color_key in self._adata.uns and len(self._adata.uns[color_key]) != len(
-            self._metastable_states.cat.categories
+            self._meta_states.cat.categories
         ):
             del self._adata.uns[_colors(self._rc_key)]
-            self._metastable_states_colors = None
+            self._meta_states_colors = None
 
         color = self._rc_key if cluster_key is None else [cluster_key, self._rc_key]
         scv.pl.scatter(self._adata, color=color, **kwargs)
 
         if color_key in self._adata.uns:
-            self._metastable_states_colors = self._adata.uns[color_key]
+            self._meta_states_colors = self._adata.uns[color_key]
 
     def compute_lin_probs(
         self,
@@ -625,7 +625,7 @@ class CFLARE(BaseEstimator):
             Nothing, but updates the following fields: :paramref:`lineage_probabilities`, :paramref:`diff_potential`.
         """
 
-        if self._metastable_states is None:
+        if self._meta_states is None:
             raise RuntimeError(
                 "Compute approximate recurrent classes first as `.compute_metastable_states()`"
             )
@@ -648,9 +648,7 @@ class CFLARE(BaseEstimator):
 
         # process the current annotations according to `keys`
         metastable_states_, colors_ = _process_series(
-            series=self._metastable_states,
-            keys=keys,
-            colors=self._metastable_states_colors,
+            series=self._meta_states, keys=keys, colors=self._meta_states_colors
         )
 
         #  create empty lineage object
@@ -825,23 +823,23 @@ class CFLARE(BaseEstimator):
         return c
 
     def _check_and_create_colors(self):
-        n_cats = len(self._metastable_states.cat.categories)
+        n_cats = len(self._meta_states.cat.categories)
         color_key = _colors(self._rc_key)
 
-        if self._metastable_states_colors is None:
+        if self._meta_states_colors is None:
             if color_key in self._adata.uns and n_cats == len(
                 self._adata.uns[color_key]
             ):
                 logg.debug("DEBUG: Loading colors from `.adata` object")
-                self._metastable_states_colors = _convert_to_hex_colors(
+                self._meta_states_colors = _convert_to_hex_colors(
                     self._adata.uns[color_key]
                 )
             else:
-                self._metastable_states_colors = _create_categorical_colors(n_cats)
-                self._adata.uns[color_key] = self._metastable_states_colors
-        elif len(self._metastable_states_colors) != n_cats:
-            self._metastable_states_colors = _create_categorical_colors(n_cats)
-            self._adata.uns[color_key] = self._metastable_states_colors
+                self._meta_states_colors = _create_categorical_colors(n_cats)
+                self._adata.uns[color_key] = self._meta_states_colors
+        elif len(self._meta_states_colors) != n_cats:
+            self._meta_states_colors = _create_categorical_colors(n_cats)
+            self._adata.uns[color_key] = self._meta_states_colors
 
     def copy(self) -> "CFLARE":
         """
@@ -864,7 +862,7 @@ class CFLARE(BaseEstimator):
 
         c._metastable_states = copy(self.metastable_states)
         c._metastable_states_probs = copy(self.metastable_states_probabilities)
-        c._metastable_states_colors = copy(self._metastable_states_colors)
+        c._metastable_states_colors = copy(self._meta_states_colors)
 
         c._G2M_score = copy(self._G2M_score)
         c._S_score = copy(self._S_score)
@@ -904,7 +902,7 @@ class CFLARE(BaseEstimator):
         :class:`pandas.Series`
             The approximate recurrent classes, where `NaN` marks cells which are transient.
         """
-        return self._metastable_states
+        return self._meta_states
 
     @property
     def metastable_states_probabilities(self) -> Series:
@@ -914,4 +912,4 @@ class CFLARE(BaseEstimator):
         :class:`pandas.Series`
             Probabilities of cells belonging to the approximate recurrent classes.
         """
-        return self._metastable_states_probs
+        return self._meta_states_probs

--- a/cellrank/tools/estimators/_cflare.py
+++ b/cellrank/tools/estimators/_cflare.py
@@ -357,7 +357,7 @@ class CFLARE(BaseEstimator):
         """
 
         self._set_categorical_labels(
-            attr_key="_metastable_states",
+            attr_key="_meta_states",
             pretty_attr_key="approx_recurrent_classes",
             cat_key=self._rc_key,
             add_to_existing_error_msg="Compute approximate recurrent classes first as `.compute_metastable_states()`.",

--- a/tests/test_markov_chain.py
+++ b/tests/test_markov_chain.py
@@ -200,8 +200,7 @@ class TestMarkovChain:
         arc_colors = [
             c
             for arc, c in zip(
-                mc_fwd.metastable_states.cat.categories,
-                mc_fwd._metastable_states_colors,
+                mc_fwd.metastable_states.cat.categories, mc_fwd._meta_states_colors
             )
             if arc in arcs
         ]
@@ -243,7 +242,7 @@ class TestMarkovChain:
 
         mc_fwd.compute_metastable_states(use=3)
 
-        mc_fwd._metastable_states_colors = None
+        mc_fwd._meta_states_colors = None
         del mc_fwd.adata.uns[_colors(RcKey.FORWARD)]
 
         mc_fwd._check_and_create_colors()
@@ -253,7 +252,7 @@ class TestMarkovChain:
             mc_fwd.adata.uns[_colors(RcKey.FORWARD)], _create_categorical_colors(3)
         )
         np.testing.assert_array_equal(
-            mc_fwd.adata.uns[_colors(RcKey.FORWARD)], mc_fwd._metastable_states_colors
+            mc_fwd.adata.uns[_colors(RcKey.FORWARD)], mc_fwd._meta_states_colors
         )
 
 
@@ -286,9 +285,7 @@ class TestMarkovChainCopy:
         np.testing.assert_array_equal(
             mc1.metastable_states_probabilities, mc2.metastable_states_probabilities
         )
-        np.testing.assert_array_equal(
-            mc1._metastable_states_colors, mc2._metastable_states_colors
-        )
+        np.testing.assert_array_equal(mc1._meta_states_colors, mc2._meta_states_colors)
         assert mc1._G2M_score == mc2._G2M_score
         assert mc1._S_score == mc2._S_score
 
@@ -314,6 +311,6 @@ class TestMarkovChainCopy:
             mc1.metastable_states_probabilities
             is not mc2.metastable_states_probabilities
         )
-        assert mc1._metastable_states_colors is not mc2._metastable_states_colors
+        assert mc1._meta_states_colors is not mc2._meta_states_colors
         assert mc1._G2M_score != mc2._G2M_score
         assert mc1._S_score != mc2._S_score


### PR DESCRIPTION
This 
- make the first eigenvector constant for irr. mat, just for plotting (num. errors cause it not to be const. )
- changes naming to be consistent with GPCCA class