### PR TITLE
Check velocity graph parameters

### DIFF
--- a/cellrank/tools/kernels/_kernel.py
+++ b/cellrank/tools/kernels/_kernel.py
@@ -742,6 +742,20 @@ class VelocityKernel(Kernel):
                 "Compute cosine correlations first as `scvelo.tl.velocity_graph()`."
             )
 
+        # check the velocity parameters
+        if vkey + "_params" in self.adata.uns.keys():
+            velocity_params = self.adata.uns[vkey + "_params"]
+            if velocity_params["mode_neighbors"] != "connectivities":
+                logg.warning(
+                    'Please re-compute the scvelo velocity graph using `mode_neighbors="connectivities"`'
+                )
+            if velocity_params["n_recurse_neighbors"] not in [0, 1]:
+                logg.warning(
+                    "Please re-compute the scvelo velocity graph using `n_recurse_neighbors=0`"
+                )
+        else:
+            logg.debug("Unable to check velocity graph parameters")
+
         velo_corr_pos, velo_corr_neg = (
             csr_matrix(self.adata.uns[vkey + "_graph"]).copy(),
             csr_matrix(self.adata.uns[vkey + "_graph_neg"]).copy(),


### PR DESCRIPTION
this checks whether the velocity graph from scvelo has been computed using `n_recurse_neighbors` either 0 or 1 and `mode_neighbors='connectivities'`, which are important settings. 