### PR TITLE
Add compute_schur

### DIFF
--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -161,7 +161,7 @@ class GPCCA(BaseEstimator):
 
         if self.schur_vectors is None:
             raise RuntimeError(
-                "Compute Schur vectors as `.compute_metastable_states()` with `n_states` > 1 first."
+                "Compute Schur vectors as `.compute_schur()` or `.compute_metastable_states()` with `n_states` > 1."
             )
 
         self._plot_vectors(
@@ -208,7 +208,7 @@ class GPCCA(BaseEstimator):
 
         if self._schur_matrix is None:
             raise RuntimeError(
-                "Compute Schur matrix as `.compute_metastable_states()` with `n_states` > 1 first."
+                "Compute Schur matrix first as `compute_schur()` or `.compute_metastable_states()` with `n_states` > 1."
             )
 
         fig, ax = plt.subplots(
@@ -283,6 +283,9 @@ class GPCCA(BaseEstimator):
         Returns
         -------
         None
+            Nothings, but updates the following fields:
+
+                - :paramref:`schur_vectors`
         """
 
         if n_vectors < 2:

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -258,7 +258,7 @@ class GPCCA(BaseEstimator):
 
     def compute_schur(
         self,
-        n_vectors: int,
+        n_vectors: int = 10,
         initial_distribution: Optional[np.ndarray] = None,
         method: str = "krylov",
         which: str = "LM",

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -268,7 +268,7 @@ class GPCCA(BaseEstimator):
 
         Params
         ------
-        n_states
+        n_vectors
             Number of vectors to compute.
         initial_distribution
             Input probability distribution over all cells. If `None`, uniform is chosen.

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -208,7 +208,7 @@ class GPCCA(BaseEstimator):
 
         if self._schur_matrix is None:
             raise RuntimeError(
-                "Compute Schur matrix first as `compute_schur()` or `.compute_metastable_states()` with `n_states` > 1."
+                "Compute Schur matrix first as `.compute_schur()` or `.compute_metastable_states()` with `n_states` > 1."
             )
 
         fig, ax = plt.subplots(


### PR DESCRIPTION
Implements #138 
@Marius1311 I need your feedback on this. I've decoupled the computation of Schur vectors and the metastable states - there's the function `compute_schur(n_vectors, init_dist, method, which)` which just calls (`_do_schur_helper`). Afterwards, you can plot the vectors/matrix using `plot_schur_embedding()` or `plot_schur_matrix()`.
Then, you can specify number of states in `compute_metastable_states` - if it's <= #previously computed vectors, you don't recompute it, otherwise, it warns you and computes the new decomposition.
In #138 2., you also mention the ED - however, as it currently stands, there's no way for me to access it or pass it to `msmtools.GPCCA`. I'd leave it for now.
Let me know what you think and whether this is what you've wanted. If so, I will merge and start writing tests.