### PR TITLE
Refactor select cells

### DIFF
--- a/cellrank/tools/_colors.py
+++ b/cellrank/tools/_colors.py
@@ -239,7 +239,7 @@ def _map_names_and_colors(
         )
         if len(critical_cats) > 0:
             logg.warning(
-                f"The following groups could not be mapped uniquely: `{', '.join(map(str, critical_cats))}`"
+                f"The following states could not be mapped uniquely: `{', '.join(map(str, critical_cats))}`"
             )
 
     return (

--- a/cellrank/tools/_lineage.py
+++ b/cellrank/tools/_lineage.py
@@ -187,7 +187,6 @@ class Lineage(np.ndarray):
                     return self._mixer(rows, col)
                 col = self._maybe_convert_names(col)
                 item = rows, col
-
         else:
             if isinstance(item, (int, np.integer, str)):
                 item = [item]
@@ -211,6 +210,10 @@ class Lineage(np.ndarray):
             is_tuple_len_2
             and not isinstance(item[0], slice)
             and not isinstance(item[1], slice)
+            and hasattr(item[0], "__len__")
+            and len(item[0])
+            and hasattr(item[1], "__len__")
+            and len(item[1])
         ):
             item_0 = (
                 np.array(item[0]) if not isinstance(item[0], np.ndarray) else item[0]
@@ -303,11 +306,13 @@ class Lineage(np.ndarray):
 
     def _maybe_convert_names(
         self,
-        names: Iterable[Union[int, str]],
+        names: Iterable[Union[int, str, bool]],
         is_singleton: bool = False,
         default: Optional[Union[int, str]] = None,
         make_unique: bool = True,
-    ) -> Union[int, List[int]]:
+    ) -> Union[int, List[int], List[bool]]:
+        if all(map(lambda n: isinstance(n, (bool, np.bool_)), names)):
+            return list(names)
         res = []
         for name in names:
             if isinstance(name, str):

--- a/cellrank/tools/_lineage.py
+++ b/cellrank/tools/_lineage.py
@@ -210,10 +210,6 @@ class Lineage(np.ndarray):
             is_tuple_len_2
             and not isinstance(item[0], slice)
             and not isinstance(item[1], slice)
-            and hasattr(item[0], "__len__")
-            and len(item[0])
-            and hasattr(item[1], "__len__")
-            and len(item[1])
         ):
             item_0 = (
                 np.array(item[0]) if not isinstance(item[0], np.ndarray) else item[0]

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -17,12 +17,6 @@ from typing import (
 )
 from itertools import tee, product, combinations
 
-import matplotlib.colors as mcolors
-
-import scanpy as sc
-from scanpy import logging as logg
-from anndata import AnnData
-
 import numpy as np
 import pandas as pd
 import networkx as nx
@@ -33,6 +27,13 @@ from sklearn.cluster import KMeans
 from pandas.api.types import infer_dtype, is_categorical_dtype
 from sklearn.neighbors import NearestNeighbors
 from scipy.sparse.linalg import norm as s_norm
+
+import matplotlib.colors as mcolors
+
+import scanpy as sc
+from scanpy import logging as logg
+from anndata import AnnData
+
 from cellrank.utils._utils import _get_neighs, _has_neighs, _get_neighs_params
 from cellrank.tools._colors import _convert_to_hex_colors, _insert_categorical_colors
 
@@ -1158,12 +1159,10 @@ def _one_hot(n, cat: Optional[int] = None) -> np.ndarray:
 
     If cat is None, return a vector of zeros.
     """
-    if cat is not None and cat >= n:
-        raise ValueError(f"Can't one-hot encode {cat} with a vector of length only {n}")
 
-    out = np.zeros(n)
+    out = np.zeros(n, dtype="bool")
     if cat is not None:
-        out[cat] = 1
+        out[cat] = True
 
     return out
 
@@ -1237,9 +1236,9 @@ def _fuzzy_to_discrete(
     }
 
     # create the one-hot encoded discrete clustering
-    a_discrete = np.zeros_like(a_fuzzy)
+    a_discrete = np.zeros_like(a_fuzzy, dtype="bool")
     for ix in range(n_clusters):
-        a_discrete[sample_assignment[ix], ix] = 1
+        a_discrete[sample_assignment[ix], ix] = True
 
     # handle samples assigned to more than one cluster
     critical_samples = np.where(a_discrete.sum(1) > 1)[0]

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1310,6 +1310,8 @@ def _series_from_one_hot_matrix(
 
     if not np.all(a.sum(axis=1) <= 1):
         raise ValueError("Not all items are one-hot encoded or empty.")
+    if (a.sum(0) == 0).any():
+        logg.warning(f"Detected {np.sum((a.sum(0) == 0))} empty categorie(s) ")
 
     if index is None:
         index = range(n_samples)

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1233,7 +1233,7 @@ def _fuzzy_to_discrete(
 
     # initially select `n_most_likely` samples per cluster
     sample_assignment = {
-        cl: fuzzy_assignment.argsort()[::-1][:n_most_likely]
+        cl: fuzzy_assignment.argpartition(n_most_likely)[:n_most_likely]
         for cl, fuzzy_assignment in enumerate(a_fuzzy.T)
     }
 

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1307,6 +1307,9 @@ def _series_from_one_hot_matrix(
             f"Expected `a`'s elements to be boolean, found `{a.dtype.name}`."
         )
 
+    if not np.all(a.sum(axis=1) <= 1):
+        raise ValueError("At most 1 category can be one-hot encoded.")
+
     if index is None:
         index = range(n_samples)
     if names is not None:

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -17,12 +17,6 @@ from typing import (
 )
 from itertools import tee, product, combinations
 
-import matplotlib.colors as mcolors
-
-import scanpy as sc
-from scanpy import logging as logg
-from anndata import AnnData
-
 import numpy as np
 import pandas as pd
 import networkx as nx
@@ -33,6 +27,13 @@ from sklearn.cluster import KMeans
 from pandas.api.types import infer_dtype, is_categorical_dtype
 from sklearn.neighbors import NearestNeighbors
 from scipy.sparse.linalg import norm as s_norm
+
+import matplotlib.colors as mcolors
+
+import scanpy as sc
+from scanpy import logging as logg
+from anndata import AnnData
+
 from cellrank.utils._utils import _get_neighs, _has_neighs, _get_neighs_params
 from cellrank.tools._colors import _convert_to_hex_colors, _insert_categorical_colors
 
@@ -1301,6 +1302,7 @@ def _series_from_one_hot_matrix(
         raise TypeError(
             f"Expected `a` to be of type `numpy.ndarray`, found `{type(a).__name__!r}`."
         )
+    a = np.asarray(a)  # change the type in case a lineage object was passed.
     if a.dtype != np.bool:
         raise TypeError(
             f"Expected `a`'s elements to be boolean, found `{a.dtype.name}`."

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1159,7 +1159,7 @@ def _one_hot(n, cat: Optional[int] = None) -> np.ndarray:
     If cat is None, return a vector of zeros.
     """
 
-    out = np.zeros(n, dtype="bool")
+    out = np.zeros(n, dtype=np.bool)
     if cat is not None:
         out[cat] = True
 
@@ -1211,7 +1211,7 @@ def _fuzzy_to_discrete(
         Array of clusters with less than `n_most_likely` samples assigned.
     """
     # check the inputs
-    n_samples, n_clusters = a_fuzzy.shape[0], a_fuzzy.shape[1]
+    n_samples, n_clusters = a_fuzzy.shape
     if not isinstance(a_fuzzy, np.ndarray):
         raise TypeError(
             f"Expected `a_fuzzy` to be of type `numpy.ndarray`, got `{type(a_fuzzy).__name__!r}`."
@@ -1297,11 +1297,16 @@ def _series_from_one_hot_matrix(
         Pandas Series, indicating cluster membership for each sample. The dtype of the categories is `str`
         and samples that belong to no cluster are assigned `NaN`.
     """
-    n_clusters, n_samples = a.shape[1], a.shape[0]
+    n_samples, n_clusters = a.shape
     if not isinstance(a, np.ndarray):
         raise TypeError(
-            f"Expected `a` to be of type `numpy.ndarray`, got `{type(a).__name__!r}`."
+            f"Expected `a` to be of type `numpy.ndarray`, found `{type(a).__name__!r}`."
         )
+    if a.dtype != np.bool:
+        raise TypeError(
+            f"Expected `a`'s elements to be boolean, found `{a.dtype.name}`."
+        )
+
     if index is None:
         index = range(n_samples)
     if names is not None:

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -17,6 +17,12 @@ from typing import (
 )
 from itertools import tee, product, combinations
 
+import matplotlib.colors as mcolors
+
+import scanpy as sc
+from scanpy import logging as logg
+from anndata import AnnData
+
 import numpy as np
 import pandas as pd
 import networkx as nx
@@ -27,13 +33,6 @@ from sklearn.cluster import KMeans
 from pandas.api.types import infer_dtype, is_categorical_dtype
 from sklearn.neighbors import NearestNeighbors
 from scipy.sparse.linalg import norm as s_norm
-
-import matplotlib.colors as mcolors
-
-import scanpy as sc
-from scanpy import logging as logg
-from anndata import AnnData
-
 from cellrank.utils._utils import _get_neighs, _has_neighs, _get_neighs_params
 from cellrank.tools._colors import _convert_to_hex_colors, _insert_categorical_colors
 
@@ -1308,7 +1307,7 @@ def _series_from_one_hot_matrix(
         )
 
     if not np.all(a.sum(axis=1) <= 1):
-        raise ValueError("At most 1 category can be one-hot encoded.")
+        raise ValueError("Not all items are one-hot encoded or empty.")
 
     if index is None:
         index = range(n_samples)

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1169,7 +1169,7 @@ def _one_hot(n, cat: Optional[int] = None) -> np.ndarray:
 
 def _fuzzy_to_discrete(
     a_fuzzy: np.array,
-    n_most_likely: Optional[int] = None,
+    n_most_likely: int = 10,
     remove_overlap: bool = True,
     raise_threshold: Optional[float] = 0.2,
 ) -> Tuple[np.ndarray, np.ndarray]:
@@ -1202,8 +1202,7 @@ def _fuzzy_to_discrete(
         If `True`, remove ambigious samples. Otherwise, assign them to the most likely cluster.
     raise_threshold
         If a cluster is assigned less than `raise_threshold x n_most_likely` samples, raise an
-        exception. Set to `None` if you never want to raise an exception, even if this leaves
-        some clusters empty.
+        exception. Set to `None` if you only want to raise if there is an empty cluster.
 
     Returns
     -------
@@ -1226,12 +1225,15 @@ def _fuzzy_to_discrete(
     if n_most_likely > int(n_samples / n_clusters):
         raise ValueError(
             f"You selected {n_most_likely} cells, please decrease this to at most {int(n_samples / n_clusters)} cells "
-            f"for your dataset of {n_samples} cells. "
+            f"for your dataset. "
         )
 
     # initialise
     if raise_threshold is not None:
-        n_raise = int(raise_threshold * n_most_likely)
+        n_raise = np.max([int(raise_threshold * n_most_likely), 1])
+    else:
+        n_raise = 1
+    logg.debug(f"DEBUG: Raising if there are less than {n_raise} cells. ")
 
     # initially select `n_most_likely` samples per cluster
     sample_assignment = {

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1210,13 +1210,13 @@ def _fuzzy_to_discrete(
     critical_clusters
         Array of clusters with less than `n_most_likely` samples assigned.
     """
-
     # check the inputs
-    n_clusters, n_samples = a_fuzzy.shape[1], a_fuzzy.shape[0]
+    n_samples, n_clusters = a_fuzzy.shape[0], a_fuzzy.shape[1]
     if not isinstance(a_fuzzy, np.ndarray):
         raise TypeError(
             f"Expected `a_fuzzy` to be of type `numpy.ndarray`, got `{type(a_fuzzy).__name__!r}`."
         )
+    a_fuzzy = np.array(a_fuzzy)  # convert to array from lineage classs
     if n_clusters != 1 and not np.allclose(
         a_fuzzy.sum(1), 1, rtol=1e3 * EPS, atol=1e3 * EPS
     ):
@@ -1244,7 +1244,9 @@ def _fuzzy_to_discrete(
     }
 
     # create the one-hot encoded discrete clustering
-    a_discrete = np.zeros_like(a_fuzzy, dtype="bool")
+    a_discrete = np.zeros(
+        a_fuzzy.shape, dtype=np.bool
+    )  # don't use `zeros_like` - it also copies the dtype
     for ix in range(n_clusters):
         a_discrete[sample_assignment[ix], ix] = True
 
@@ -1256,7 +1258,7 @@ def _fuzzy_to_discrete(
         else:
             candidate_ixs = np.where(a_discrete[sample_ix, :])[0]
             most_likely_ix = candidate_ixs[
-                np.argmax(a_fuzzy[sample_ix, a_discrete[sample_ix, :]])
+                np.argmax(a_fuzzy[sample_ix, list(a_discrete[sample_ix, :])])
             ]
             a_discrete[sample_ix, :] = _one_hot(n_clusters, most_likely_ix)
 

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1214,15 +1214,17 @@ def _fuzzy_to_discrete(
     """
 
     # check the inputs
+    n_clusters = a_fuzzy.shape[1]
     if not isinstance(a_fuzzy, np.ndarray):
         raise TypeError(
             f"Expected `a_fuzzy` to be of type `numpy.ndarray`, got `{type(a_fuzzy).__name__!r}`."
         )
-    if not np.allclose(a_fuzzy.sum(1), 1, rtol=1e3 * EPS, atol=1e3 * EPS):
+    if n_clusters != 1 and not np.allclose(
+        a_fuzzy.sum(1), 1, rtol=1e3 * EPS, atol=1e3 * EPS
+    ):
         raise ValueError("Rows in `a_fuzzy` do not sum to one.")
 
     # initialise
-    n_clusters = a_fuzzy.shape[1]
     if raise_threshold is not None:
         n_raise = int(raise_threshold * n_most_likely)
 

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -17,12 +17,6 @@ from typing import (
 )
 from itertools import tee, product, combinations
 
-import matplotlib.colors as mcolors
-
-import scanpy as sc
-from scanpy import logging as logg
-from anndata import AnnData
-
 import numpy as np
 import pandas as pd
 import networkx as nx
@@ -33,6 +27,13 @@ from sklearn.cluster import KMeans
 from pandas.api.types import infer_dtype, is_categorical_dtype
 from sklearn.neighbors import NearestNeighbors
 from scipy.sparse.linalg import norm as s_norm
+
+import matplotlib.colors as mcolors
+
+import scanpy as sc
+from scanpy import logging as logg
+from anndata import AnnData
+
 from cellrank.utils._utils import _get_neighs, _has_neighs, _get_neighs_params
 from cellrank.tools._colors import _convert_to_hex_colors, _insert_categorical_colors
 
@@ -1213,7 +1214,7 @@ def _fuzzy_to_discrete(
     """
 
     # check the inputs
-    n_clusters = a_fuzzy.shape[1]
+    n_clusters, n_samples = a_fuzzy.shape[1], a_fuzzy.shape[0]
     if not isinstance(a_fuzzy, np.ndarray):
         raise TypeError(
             f"Expected `a_fuzzy` to be of type `numpy.ndarray`, got `{type(a_fuzzy).__name__!r}`."
@@ -1222,6 +1223,10 @@ def _fuzzy_to_discrete(
         a_fuzzy.sum(1), 1, rtol=1e3 * EPS, atol=1e3 * EPS
     ):
         raise ValueError("Rows in `a_fuzzy` do not sum to one.")
+    if n_most_likely > int(n_samples / n_clusters):
+        raise ValueError(
+            "Please select fewer cells. For most datasets, reasonable values are in the range [10, 100]. "
+        )
 
     # initialise
     if raise_threshold is not None:

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -17,6 +17,12 @@ from typing import (
 )
 from itertools import tee, product, combinations
 
+import matplotlib.colors as mcolors
+
+import scanpy as sc
+from scanpy import logging as logg
+from anndata import AnnData
+
 import numpy as np
 import pandas as pd
 import networkx as nx
@@ -27,13 +33,6 @@ from sklearn.cluster import KMeans
 from pandas.api.types import infer_dtype, is_categorical_dtype
 from sklearn.neighbors import NearestNeighbors
 from scipy.sparse.linalg import norm as s_norm
-
-import matplotlib.colors as mcolors
-
-import scanpy as sc
-from scanpy import logging as logg
-from anndata import AnnData
-
 from cellrank.utils._utils import _get_neighs, _has_neighs, _get_neighs_params
 from cellrank.tools._colors import _convert_to_hex_colors, _insert_categorical_colors
 
@@ -1233,7 +1232,7 @@ def _fuzzy_to_discrete(
 
     # initially select `n_most_likely` samples per cluster
     sample_assignment = {
-        cl: fuzzy_assignment.argpartition(n_most_likely)[:n_most_likely]
+        cl: fuzzy_assignment.argpartition(-n_most_likely)[-n_most_likely:]
         for cl, fuzzy_assignment in enumerate(a_fuzzy.T)
     }
 

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1216,6 +1216,10 @@ def _fuzzy_to_discrete(
     """
 
     # check the inputs
+    if not type(a_fuzzy) == np.ndarray:
+        raise ValueError(
+            f"Expected `a_fuzzy` to be of type `numpy.ndarray`, got {type(a_fuzzy)}"
+        )
     assert np.allclose(
         a_fuzzy.sum(1), 1, rtol=1e3 * EPS, atol=1e3 * EPS
     ), "Rows in `a_fuzzy` do not sum to one. "
@@ -1277,6 +1281,8 @@ def _series_from_one_hot_matrix(a: np.array, index: Optional[Iterable] = None):
         Pandas Series, indicating cluster membership for each sample. The dtype of the categories is `str`
         and samples that belong to no cluster are assigned `NaN`
     """
+    if not type(a) == np.ndarray:
+        raise ValueError(f"Expected `a` to be of type `numpy.ndarray`, got {type(a)}")
 
     # create array of assignments, turn it into a Series
     n_clusters = a.shape[1]
@@ -1289,7 +1295,8 @@ def _series_from_one_hot_matrix(a: np.array, index: Optional[Iterable] = None):
             1,
         ).sum(1)
         - 1
-    )
+    ).flatten()
+
     cluster_series = Series(cluster_series, index=index, dtype="category")
 
     # remove the dummy '-1' category and change the dtype of the categories to be `str`

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1226,7 +1226,7 @@ def _fuzzy_to_discrete(
     if n_most_likely > int(n_samples / n_clusters):
         raise ValueError(
             f"You selected {n_most_likely} cells, please decrease this to at most {int(n_samples / n_clusters)} cells "
-            f"for your dataset. "
+            f"for your dataset of {n_samples} cells. "
         )
 
     # initialise

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1216,7 +1216,7 @@ def _fuzzy_to_discrete(
         raise TypeError(
             f"Expected `a_fuzzy` to be of type `numpy.ndarray`, got `{type(a_fuzzy).__name__!r}`."
         )
-    a_fuzzy = np.array(a_fuzzy)  # convert to array from lineage classs
+    a_fuzzy = np.asarray(a_fuzzy)  # convert to array from lineage classs, don't copy
     if n_clusters != 1 and not np.allclose(
         a_fuzzy.sum(1), 1, rtol=1e3 * EPS, atol=1e3 * EPS
     ):

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1225,7 +1225,8 @@ def _fuzzy_to_discrete(
         raise ValueError("Rows in `a_fuzzy` do not sum to one.")
     if n_most_likely > int(n_samples / n_clusters):
         raise ValueError(
-            "Please select fewer cells. For most datasets, reasonable values are in the range [10, 100]. "
+            f"You selected {n_most_likely} cells, please decrease this to at most {int(n_samples / n_clusters)} cells "
+            f"for your dataset. "
         )
 
     # initialise

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -39,7 +39,6 @@ from cellrank.tools._colors import _convert_to_hex_colors, _insert_categorical_c
 
 ColorLike = TypeVar("ColorLike")
 GPCCA = TypeVar("GPCCA")
-Lineage = TypeVar("Lineage")
 EPS = np.finfo(np.float64).eps
 
 
@@ -1224,16 +1223,19 @@ def _fuzzy_to_discrete(
         raise ValueError("Rows in `a_fuzzy` do not sum to one.")
     if n_most_likely > int(n_samples / n_clusters):
         raise ValueError(
-            f"You selected {n_most_likely} cells, please decrease this to at most {int(n_samples / n_clusters)} cells "
-            f"for your dataset. "
+            f"You've selected {n_most_likely} cells, please decrease this to at most "
+            f"{int(n_samples / n_clusters)} cells for your dataset."
         )
 
     # initialise
-    if raise_threshold is not None:
-        n_raise = np.max([int(raise_threshold * n_most_likely), 1])
-    else:
-        n_raise = 1
-    logg.debug(f"DEBUG: Raising if there are less than {n_raise} cells. ")
+    n_raise = (
+        1
+        if raise_threshold is None
+        else np.max([int(raise_threshold * n_most_likely), 1])
+    )
+    logg.debug(
+        f"DEBUG: Raising an exception if if there are less than `{n_raise}` cells."
+    )
 
     # initially select `n_most_likely` samples per cluster
     sample_assignment = {
@@ -1263,11 +1265,11 @@ def _fuzzy_to_discrete(
     if raise_threshold is not None:
         if (n_samples_per_cluster < n_raise).any():
             raise ValueError(
-                f"Discretizing leads to a cluster with less than {n_raise} samples. "
+                f"Discretizing leads to a cluster with less than `{n_raise}` samples. "
                 f"Consider recomputing the fuzzy clustering."
             )
     if (n_samples_per_cluster > n_most_likely).any():
-        raise ValueError("Assigned more samples than requested. ")
+        raise ValueError("Assigned more samples than requested.")
     critical_clusters = np.where(n_samples_per_cluster < n_most_likely)[0]
 
     return a_discrete, critical_clusters
@@ -1294,7 +1296,7 @@ def _series_from_one_hot_matrix(
         and samples that belong to no cluster are assigned `NaN`.
     """
     n_clusters, n_samples = a.shape[1], a.shape[0]
-    if not type(a) == np.ndarray:
+    if not isinstance(a, np.ndarray):
         raise TypeError(
             f"Expected `a` to be of type `numpy.ndarray`, got `{type(a).__name__!r}`."
         )

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1296,8 +1296,9 @@ def _series_from_one_hot_matrix(
     else:
         names = np.arange(n_clusters).astype("str")
 
-    target_series = pd.Series(index=index)
+    target_series = pd.Series(index=index, dtype="category")
     for (vec, name) in zip(a.T, names):
+        target_series.cat.add_categories(name, inplace=True)
         target_series[np.where(vec)[0]] = name
 
-    return target_series.astype("category")
+    return target_series

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1168,7 +1168,7 @@ def _one_hot(n, cat: Optional[int] = None):
     return out
 
 
-def _fuzzy_to_discrete_simplified(
+def _fuzzy_to_discrete(
     a_fuzzy: np.array,
     n_most_likely: Optional[int] = None,
     remove_overlap: bool = True,

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -691,13 +691,13 @@ class GPCCA(BaseEstimator):
 
         probs = self._lin_probs[[n for n in self._lin_probs.names if n != "rest"]]
         a_discrete, _ = _fuzzy_to_discrete(
-            a_fuzzy=probs,
+            a_fuzzy=probs.X,
             n_most_likely=n_cells,
             remove_overlap=False,
             raise_threshhold=0.2,
         )
         self._main_states = _series_from_one_hot_matrix(
-            a=a_discrete, index=self.adata.obs_names
+            a=a_discrete, index=self.adata.obs_names, names=probs.names
         )
 
         if write_to_adata:
@@ -1004,13 +1004,13 @@ class GPCCA(BaseEstimator):
 
         if attr == "_meta_lin_probs":  # plotting meta_lin_probs
             a_discrete, _ = _fuzzy_to_discrete(
-                a_fuzzy=probs,
+                a_fuzzy=probs.X,
                 n_most_likely=n_cells,
                 remove_overlap=False,
                 raise_threshhold=0.2,
             )
             _main_states = _series_from_one_hot_matrix(
-                a=a_discrete, index=self.adata.obs_names
+                a=a_discrete, index=self.adata.obs_names, names=probs.names
             )
 
         elif attr == "_lin_probs":

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from scipy.stats import entropy
+from msmtools.analysis.dense.gpcca import GPCCA as _GPPCA
 
 import seaborn as sns
 import matplotlib as mpl
@@ -32,7 +33,6 @@ from cellrank.tools._utils import (
 from cellrank.tools._colors import _get_black_or_white
 from cellrank.tools._lineage import Lineage
 from cellrank.tools._constants import Lin, MetaKey, _dp, _probs, _colors, _lin_names
-from msmtools.analysis.dense.gpcca import GPCCA as _GPPCA
 from cellrank.tools.kernels._kernel import KernelExpression
 from cellrank.tools.estimators._base_estimator import BaseEstimator
 
@@ -694,7 +694,7 @@ class GPCCA(BaseEstimator):
 
         probs = self._lin_probs[[n for n in self._lin_probs.names if n != "rest"]]
         a_discrete, _ = _fuzzy_to_discrete(
-            a_fuzzy=probs.X,
+            a_fuzzy=probs,
             n_most_likely=n_cells,
             remove_overlap=REMOVE_OVERLAP,
             raise_threshold=0.2,
@@ -1007,7 +1007,7 @@ class GPCCA(BaseEstimator):
 
         if attr == "_meta_lin_probs":  # plotting meta_lin_probs
             a_discrete, _ = _fuzzy_to_discrete(
-                a_fuzzy=probs.X,
+                a_fuzzy=probs,
                 n_most_likely=n_cells,
                 remove_overlap=REMOVE_OVERLAP,
                 raise_threshold=0.2,

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -36,6 +36,9 @@ from msmtools.analysis.dense.gpcca import GPCCA as _GPPCA
 from cellrank.tools.kernels._kernel import KernelExpression
 from cellrank.tools.estimators._base_estimator import BaseEstimator
 
+# whether to remove overlapping cells from both states, or assign them to the most likely clusters
+REMOVE_OVERLAP = False
+
 
 class GPCCA(BaseEstimator):
     """
@@ -693,7 +696,7 @@ class GPCCA(BaseEstimator):
         a_discrete, _ = _fuzzy_to_discrete(
             a_fuzzy=probs.X,
             n_most_likely=n_cells,
-            remove_overlap=False,
+            remove_overlap=REMOVE_OVERLAP,
             raise_threshold=0.2,
         )
         self._main_states = _series_from_one_hot_matrix(
@@ -918,7 +921,7 @@ class GPCCA(BaseEstimator):
             a_discrete, not_enough_cells = _fuzzy_to_discrete(
                 a_fuzzy=memberships,
                 n_most_likely=n_cells,
-                remove_overlap=False,
+                remove_overlap=REMOVE_OVERLAP,
                 raise_threshold=0.2,
             )
             metastable_states = _series_from_one_hot_matrix(
@@ -1006,7 +1009,7 @@ class GPCCA(BaseEstimator):
             a_discrete, _ = _fuzzy_to_discrete(
                 a_fuzzy=probs.X,
                 n_most_likely=n_cells,
-                remove_overlap=False,
+                remove_overlap=REMOVE_OVERLAP,
                 raise_threshold=0.2,
             )
             _main_states = _series_from_one_hot_matrix(

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -940,7 +940,7 @@ class GPCCA(BaseEstimator):
             add_to_existing=False,
         )
         name_mapper = dict(zip(orig_cats, self.metastable_states.cat.categories))
-        _warn_insufficient_number_of_cells(
+        _print_insufficient_number_of_cells(
             [name_mapper.get(n, n) for n in not_enough_cells], n_cells
         )
 
@@ -1481,9 +1481,9 @@ class GPCCA(BaseEstimator):
         return self._main_states_probabilities
 
 
-def _warn_insufficient_number_of_cells(groups: Iterable[Any], n_cells: int):
+def _print_insufficient_number_of_cells(groups: Iterable[Any], n_cells: int):
     if groups:
-        logg.warning(
-            f"The following groups have less than requested number of cells ({n_cells}): "
+        logg.debug(
+            f"DEBUG: The following groups have less than requested number of cells ({n_cells}): "
             f"`{', '.join(sorted(map(str, groups)))}`"
         )

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -1012,6 +1012,7 @@ class GPCCA(BaseEstimator):
             _main_states = _series_from_one_hot_matrix(
                 a=a_discrete, index=self.adata.obs_names
             )
+
         elif attr == "_lin_probs":
             if n_cells == self._n_cells:
                 logg.debug("DEBUG: Using cached main states")

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -6,6 +6,11 @@ from types import MappingProxyType
 from typing import Any, Dict, List, Tuple, Union, Mapping, Iterable, Optional
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
+from scipy.stats import entropy
+from pandas.api.types import is_categorical_dtype
+
 import seaborn as sns
 import matplotlib as mpl
 import matplotlib.cm as cm
@@ -17,10 +22,6 @@ import scvelo as scv
 from scanpy import logging as logg
 from anndata import AnnData
 
-import numpy as np
-import pandas as pd
-from scipy.stats import entropy
-from pandas.api.types import is_categorical_dtype
 from cellrank.tools._utils import (
     save_fig,
     _eigengap,
@@ -1010,12 +1011,12 @@ class GPCCA(BaseEstimator):
             logg.debug(
                 "DEBUG: Setting the metastable states using metastable memberships"
             )
-            metastable_states, not_enough_cells = self._select_cells(
-                n_cells,
-                memberships=memberships,
-                meta_assignment=_meta_assignment,
-                warn=False,
-            )
+            # metastable_states, not_enough_cells = self._select_cells(
+            #     n_cells,
+            #     memberships=memberships,
+            #     meta_assignment=_meta_assignment,
+            #     warn=False,
+            # )
 
         # _set_categorical_labels creates the names, we still need to remap the group names
         orig_cats = metastable_states.cat.categories

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
+import mock
 import numpy as np
 import pytest
 from pandas import DataFrame
 
 import matplotlib.colors as colors
 
-import mock
 import cellrank.tools._lineage as mocker
 from cellrank.tools import Lineage
 from cellrank.tools._utils import _compute_mean_color
@@ -239,6 +239,29 @@ class TestLineageAccessor:
         y = l[[1, 2, 3], :]
 
         np.testing.assert_array_equal(x[[1, 2, 3], :], np.array(y))
+
+    def test_column_subset_boolean(self):
+        x = np.random.random((10, 3))
+        l = Lineage(
+            x,
+            names=["foo", "bar", "baz"],
+            colors=[(0, 0, 0), (0.5, 0.5, 0.5), (1, 1, 1)],
+        )
+
+        y = l[:, [False, False, True]]
+
+        np.testing.assert_array_equal(x[:, -1], y.X.squeeze())
+
+    def test_column_subset_boolean_invalid_dim(self):
+        x = np.random.random((10, 3))
+        l = Lineage(
+            x,
+            names=["foo", "bar", "baz"],
+            colors=[(0, 0, 0), (0.5, 0.5, 0.5), (1, 1, 1)],
+        )
+
+        with pytest.raises(IndexError):
+            y = l[:, [True]]
 
     def test_row_subset_with_mask(self):
         x = np.random.random((10, 3))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -170,7 +170,7 @@ class TestLowLevelPipeline:
         mc_fwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
         mc_fwd.plot_schur_matrix()
 
-        mc_fwd.set_main_states()
+        mc_fwd.set_main_states(n_cells=25)
         mc_fwd.plot_main_states()
 
         mc_fwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
@@ -196,7 +196,7 @@ class TestLowLevelPipeline:
         mc_bwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
         mc_bwd.plot_schur_matrix()
 
-        mc_bwd.set_main_states()
+        mc_bwd.set_main_states(n_cells=25)
         mc_bwd.plot_main_states()
 
         mc_bwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from pandas.api.types import is_categorical_dtype
+
 from anndata import AnnData
 
 import cellrank as cr
-from pandas.api.types import is_categorical_dtype
 from cellrank.tools.kernels import VelocityKernel, ConnectivityKernel
 from cellrank.tools._constants import (
     LinKey,
@@ -164,7 +165,7 @@ class TestLowLevelPipeline:
         mc_fwd.compute_schur(5, method="brandts")
         mc_fwd.plot_schur_embedding()
 
-        mc_fwd.compute_metastable_states(2)
+        mc_fwd.compute_metastable_states(2, n_cells=25)
         mc_fwd.plot_metastable_states()
         mc_fwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
         mc_fwd.plot_schur_matrix()
@@ -190,7 +191,7 @@ class TestLowLevelPipeline:
         mc_bwd.compute_schur(5, method="brandts")
         mc_bwd.plot_schur_embedding()
 
-        mc_bwd.compute_metastable_states(2)
+        mc_bwd.compute_metastable_states(2, n_cells=25)
         mc_bwd.plot_metastable_states()
         mc_bwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
         mc_bwd.plot_schur_matrix()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -323,7 +323,7 @@ class TestOneHot:
             _ = _one_hot(10, 10)
 
 
-class FuzzyToDiscrete:
+class TestFuzzyToDiscrete:
     def test_normal_run(self):
         # create random data that sums to one row-wise
         a_fuzzy = np.random.standard_normal((100, 3))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 from pandas.api.types import is_categorical_dtype
 
 from _helpers import assert_array_nan_equal
+from cellrank.tools import Lineage
 from cellrank.tools._utils import (
     _one_hot,
     _process_series,
@@ -419,3 +420,25 @@ class FuzzyToDiscrete:
 
         assert c_1 == np.array(2)
         assert (c_2 == np.array([1, 2])).all()
+
+    def test_passing_lineage_object(self):
+        a_fuzzy = np.array(
+            [
+                [0.3, 0.7, 0],
+                [0.2, 0.5, 0.3],
+                [0.1, 0.8, 0.1],
+                [0.4, 0.4, 0.2],
+                [0.5, 0.3, 0.2],
+                [0.6, 0.3, 0.1],
+                [0.3, 0.3, 0.4],
+                [0.2, 0.2, 0.6],
+            ]
+        )
+        a_fuzzy_lin = Lineage(a_fuzzy, names=["0", "1", "2"])
+
+        b_np, c_np = _fuzzy_to_discrete(a_fuzzy=a_fuzzy, n_most_likely=2)
+        b_l, c_l = _fuzzy_to_discrete(a_fuzzy=a_fuzzy_lin, n_most_likely=2)
+
+        assert (b_np == b_l).all()
+        assert len(c_np) == 0
+        assert len(c_l) == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -372,7 +372,15 @@ class FuzzyToDiscrete:
                 [0.2, 0.2, 0.6],
             ]
         )
-        a_actual, _ = _fuzzy_to_discrete(a_fuzzy, n_most_likely=2, remove_overlap=True)
+
+        # note: removing the overlap should have no effect in this case since there is none.
+        # there should also be no critical clusters in this case
+        a_actual_1, c_1 = _fuzzy_to_discrete(
+            a_fuzzy, n_most_likely=2, remove_overlap=True
+        )
+        a_actual_2, c_2 = _fuzzy_to_discrete(
+            a_fuzzy, n_most_likely=2, remove_overlap=False
+        )
         a_expected = np.array(
             [
                 [False, True, False],
@@ -386,7 +394,10 @@ class FuzzyToDiscrete:
             ]
         )
 
-        assert (a_actual == a_expected).all()
+        assert (a_actual_1 == a_expected).all()
+        assert (a_actual_2 == a_expected).all()
+        assert len(c_1) == 0
+        assert len(c_2) == 0
 
     def test_critical_samples(self):
         a_fuzzy = np.array(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -451,7 +451,13 @@ class TestSeriesFromOneHotMatrix:
             [[0, 0, 1], [0, 0, 1], [0, 0, 0], [1, 0, 0], [1, 0, 0], [0, 1, 0]],
             dtype="bool",
         )
-        _series_from_one_hot_matrix(a)
+        res = _series_from_one_hot_matrix(a)
+
+        assert_array_nan_equal(
+            np.array(res).astype(np.float32),
+            np.array([2, 2, np.nan, 0, 0, 1], dtype=np.float32),
+        )
+        np.testing.assert_array_equal(res.cat.categories, ["0", "1", "2"])
 
     def test_name_mismatch(self):
         a = np.array(
@@ -470,15 +476,6 @@ class TestSeriesFromOneHotMatrix:
         )
 
         with pytest.raises(TypeError):
-            _series_from_one_hot_matrix(a)
-
-    def test_empty_categories(self):
-        a = np.array(
-            [[0, 0, 1], [0, 0, 1], [0, 0, 0], [0, 1, 0], [0, 0, 0], [0, 1, 0]],
-            dtype="bool",
-        )
-
-        with pytest.raises(ValueError):
             _series_from_one_hot_matrix(a)
 
     def test_normal_return(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 from pandas.api.types import is_categorical_dtype
 
 from _helpers import assert_array_nan_equal
-from cellrank.tools._utils import _process_series, _merge_categorical_series
+from cellrank.tools._utils import _one_hot, _process_series, _merge_categorical_series
 from cellrank.tools._colors import _map_names_and_colors
 
 
@@ -293,3 +293,25 @@ class TestProcessSeries:
 
         np.testing.assert_array_equal(res.values, expected.values)
         assert set(colors) == {"#804000", "#8080ff"}
+
+
+class TestOneHot:
+    def test_normal_run(self):
+        _one_hot(n=10, cat=5)
+        _one_hot(n=10, cat=None)
+
+    def test_return_vector(self):
+        a = _one_hot(n=10, cat=None)
+        b = _one_hot(n=10, cat=5)
+
+        b_check = np.zeros(10)
+        b_check[5] = True
+
+        assert a.dtype == "bool"
+        assert b.dtype == "bool"
+        assert (a == np.zeros(10)).all()
+        assert (b == b_check).all()
+
+    def test_index_error(self):
+        with pytest.raises(IndexError):
+            _ = _one_hot(10, 10)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -478,6 +478,15 @@ class TestSeriesFromOneHotMatrix:
         with pytest.raises(TypeError):
             _series_from_one_hot_matrix(a)
 
+    def test_not_one_hot(self):
+        a = np.array(
+            [[1, 0, 1], [0, 0, 1], [0, 0, 0], [1, 0, 0], [1, 0, 0], [0, 1, 0]],
+            dtype="bool",
+        )
+
+        with pytest.raises(ValueError):
+            _series_from_one_hot_matrix(a)
+
     def test_normal_return(self):
         a = np.array(
             [[0, 0, 1], [0, 0, 1], [0, 0, 0], [1, 0, 0], [1, 0, 0], [0, 1, 0]],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -396,8 +396,8 @@ class TestFuzzyToDiscrete:
             ]
         )
 
-        assert (a_actual_1 == a_expected).all()
-        assert (a_actual_2 == a_expected).all()
+        np.testing.assert_array_equal(a_actual_1, a_expected)
+        np.testing.assert_array_equal(a_actual_2, a_expected)
         assert len(c_1) == 0
         assert len(c_2) == 0
 
@@ -420,7 +420,7 @@ class TestFuzzyToDiscrete:
         _, c_2 = _fuzzy_to_discrete(a_fuzzy, n_most_likely=3, remove_overlap=True)
 
         assert c_1 == np.array(2)
-        assert (c_2 == np.array([1, 2])).all()
+        np.testing.assert_array_equal(c_2, np.array([1, 2]))
 
     def test_passing_lineage_object(self):
         a_fuzzy = np.array(
@@ -440,7 +440,7 @@ class TestFuzzyToDiscrete:
         b_np, c_np = _fuzzy_to_discrete(a_fuzzy=a_fuzzy, n_most_likely=2)
         b_l, c_l = _fuzzy_to_discrete(a_fuzzy=a_fuzzy_lin, n_most_likely=2)
 
-        assert (b_np == b_l).all()
+        np.testing.assert_array_equal(b_np, b_l)
         assert len(c_np) == 0
         assert len(c_l) == 0
 
@@ -452,8 +452,6 @@ class TestSeriesFromOneHotMatrix:
             dtype="bool",
         )
         _series_from_one_hot_matrix(a)
-
-    test_normal_run()
 
     def test_name_mismatch(self):
         a = np.array(


### PR DESCRIPTION
This changes the way in which we select cells. The central piece is a new utility function `_fuzzy_to_discrete`. This function is class-independent and should make it easier to write tests. 

The new selection function considers overlaps between all states and offers two different possibilities for dealing with it, see the docstring of `_fuzzy_to_discrete` for more details. 
