### PR TITLE
**kwargs for 1-state case

### DIFF
--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1217,7 +1217,7 @@ def _fuzzy_to_discrete(
             f"Expected `a_fuzzy` to be of type `numpy.ndarray`, got `{type(a_fuzzy).__name__!r}`."
         )
     a_fuzzy = np.asarray(a_fuzzy)  # convert to array from lineage classs, don't copy
-    if n_clusters != 1 and not np.allclose(a_fuzzy.sum(1), 1, rtol=1e5, atol=1e5):
+    if n_clusters != 1 and not np.allclose(a_fuzzy.sum(1), 1, rtol=1e-5, atol=1e-5):
         raise ValueError("Rows in `a_fuzzy` do not sum to one.")
     if n_most_likely > int(n_samples / n_clusters):
         raise ValueError(

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1217,9 +1217,7 @@ def _fuzzy_to_discrete(
             f"Expected `a_fuzzy` to be of type `numpy.ndarray`, got `{type(a_fuzzy).__name__!r}`."
         )
     a_fuzzy = np.asarray(a_fuzzy)  # convert to array from lineage classs, don't copy
-    if n_clusters != 1 and not np.allclose(
-        a_fuzzy.sum(1), 1, rtol=1e3 * EPS, atol=1e3 * EPS
-    ):
+    if n_clusters != 1 and not np.allclose(a_fuzzy.sum(1), 1, rtol=1e5, atol=1e5):
         raise ValueError("Rows in `a_fuzzy` do not sum to one.")
     if n_most_likely > int(n_samples / n_clusters):
         raise ValueError(

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1271,9 +1271,10 @@ def _fuzzy_to_discrete(
     n_samples_per_cluster = a_discrete.sum(0)
     if raise_threshold is not None:
         if (n_samples_per_cluster < n_raise).any():
+            min_samples = np.min(n_samples_per_cluster)
             raise ValueError(
-                f"Discretizing leads to a cluster with less than `{n_raise}` samples. "
-                f"Consider recomputing the fuzzy clustering."
+                f"Discretizing leads to a cluster with `{min_samples}` samples, less than the threshold which is "
+                f"`{n_raise}` samples. Consider recomputing the fuzzy clustering."
             )
     if (n_samples_per_cluster > n_most_likely).any():
         raise ValueError("Assigned more samples than requested.")

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -691,6 +691,7 @@ class GPCCA(BaseEstimator):
             n_most_likely=n_cells,
             remove_overlap=REMOVE_OVERLAP,
             raise_threshold=0.2,
+            check_row_sums=False,
         )
         self._main_states = _series_from_one_hot_matrix(
             a=a_discrete, index=self.adata.obs_names, names=probs.names

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from scipy.stats import entropy
-from msmtools.analysis.dense.gpcca import GPCCA as _GPPCA
 
 import seaborn as sns
 import matplotlib as mpl
@@ -33,6 +32,7 @@ from cellrank.tools._utils import (
 from cellrank.tools._colors import _get_black_or_white
 from cellrank.tools._lineage import Lineage
 from cellrank.tools._constants import Lin, MetaKey, _dp, _probs, _colors, _lin_names
+from msmtools.analysis.dense.gpcca import GPCCA as _GPPCA
 from cellrank.tools.kernels._kernel import KernelExpression
 from cellrank.tools.estimators._base_estimator import BaseEstimator
 
@@ -322,14 +322,11 @@ class GPCCA(BaseEstimator):
         cluster_key: Optional[str],
         en_cutoff: Optional[float],
         p_thresh: float,
-        **kwargs,
     ) -> None:
         start = logg.info("Computing metastable states")
         logg.warning("For `n_states=1`, stationary distribution is computed")
 
-        if not kwargs:
-            logg.warning("Computing eigendecomposition with default values")
-        self._compute_eig(only_evals=False, **kwargs)
+        self._compute_eig(only_evals=False, which="LM")
         stationary_dist = self.eigendecomposition["stationary_dist"]
 
         self._assign_metastable_states(

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -389,7 +389,6 @@ class GPCCA(BaseEstimator):
         cluster_key: str = None,
         en_cutoff: Optional[float] = 0.7,
         p_thresh: float = 1e-15,
-        **kwargs,
     ):
         """
         Compute the metastable states.
@@ -412,8 +411,6 @@ class GPCCA(BaseEstimator):
             start- or endpoints.
             If the test returns a positive statistic and a p-value smaller than :paramref:`p_thresh`,
             a warning will be issued.
-        kwargs
-            Keyword arguments for :meth:`compute_eig` if `n_states=1`.
 
         Returns
         -------
@@ -441,7 +438,6 @@ class GPCCA(BaseEstimator):
                 cluster_key=cluster_key,
                 p_thresh=p_thresh,
                 en_cutoff=en_cutoff,
-                **kwargs,
             )
             return
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -165,12 +165,25 @@ class TestLowLevelPipeline:
         mc_fwd.compute_schur(5, method="brandts")
         mc_fwd.plot_schur_embedding()
 
-        mc_fwd.compute_metastable_states(2, n_cells=25)
+        mc_fwd.compute_metastable_states(3, n_cells=25)
         mc_fwd.plot_metastable_states()
         mc_fwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
         mc_fwd.plot_schur_matrix()
 
+        # select all states
         mc_fwd.set_main_states(n_cells=25)
+        mc_fwd.plot_main_states()
+
+        mc_fwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
+
+        _assert_has_all_keys(adata, Direction.FORWARD)
+
+        # select a subset of states
+        mc_fwd.set_main_states(
+            n_cells=25,
+            names=self.metastable_states.cat.categories[:2],
+            redistribute=False,
+        )
         mc_fwd.plot_main_states()
 
         mc_fwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
@@ -191,14 +204,27 @@ class TestLowLevelPipeline:
         mc_bwd.compute_schur(5, method="brandts")
         mc_bwd.plot_schur_embedding()
 
-        mc_bwd.compute_metastable_states(2, n_cells=25)
+        mc_bwd.compute_metastable_states(3, n_cells=25)
         mc_bwd.plot_metastable_states()
         mc_bwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
         mc_bwd.plot_schur_matrix()
 
+        # select all cells
         mc_bwd.set_main_states(n_cells=25)
         mc_bwd.plot_main_states()
 
         mc_bwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
 
         _assert_has_all_keys(adata, Direction.BACKWARD)
+
+        # select a subset of states
+        mc_bwd.set_main_states(
+            n_cells=25,
+            names=self.metastable_states.cat.categories[:2],
+            redistribute=False,
+        )
+        mc_bwd.plot_main_states()
+
+        mc_bwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
+
+        _assert_has_all_keys(adata, Direction.FORWARD)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -227,4 +227,4 @@ class TestLowLevelPipeline:
 
         estimator_bwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
 
-        _assert_has_all_keys(adata, Direction.FORWARD)
+        _assert_has_all_keys(adata, Direction.BACKWARD)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -104,23 +104,23 @@ class TestLowLevelPipeline:
         ck = ConnectivityKernel(adata).compute_transition_matrix()
         final_kernel = 0.8 * vk + 0.2 * ck
 
-        mc_fwd = cr.tl.CFLARE(final_kernel)
+        estimator_fwd = cr.tl.CFLARE(final_kernel)
 
-        mc_fwd.compute_partition()
+        estimator_fwd.compute_partition()
 
-        mc_fwd.compute_eig()
-        mc_fwd.plot_spectrum()
-        mc_fwd.plot_spectrum(real_only=True)
-        mc_fwd.plot_eig_embedding()
-        mc_fwd.plot_eig_embedding(left=False)
+        estimator_fwd.compute_eig()
+        estimator_fwd.plot_spectrum()
+        estimator_fwd.plot_spectrum(real_only=True)
+        estimator_fwd.plot_eig_embedding()
+        estimator_fwd.plot_eig_embedding(left=False)
 
-        mc_fwd.compute_metastable_states(use=1)
-        mc_fwd.plot_metastable_states()
+        estimator_fwd.compute_metastable_states(use=1)
+        estimator_fwd.plot_metastable_states()
 
-        mc_fwd.compute_lin_probs()
-        mc_fwd.plot_lin_probs()
+        estimator_fwd.compute_lin_probs()
+        estimator_fwd.plot_lin_probs()
 
-        mc_fwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
+        estimator_fwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
 
         _assert_has_all_keys(adata, Direction.FORWARD)
 
@@ -129,23 +129,23 @@ class TestLowLevelPipeline:
         ck = ConnectivityKernel(adata, backward=True).compute_transition_matrix()
         final_kernel = 0.8 * vk + 0.2 * ck
 
-        mc_bwd = cr.tl.CFLARE(final_kernel)
+        estimator_bwd = cr.tl.CFLARE(final_kernel)
 
-        mc_bwd.compute_partition()
+        estimator_bwd.compute_partition()
 
-        mc_bwd.compute_eig()
-        mc_bwd.plot_spectrum()
-        mc_bwd.plot_spectrum(real_only=True)
-        mc_bwd.plot_eig_embedding()
-        mc_bwd.plot_eig_embedding(left=False)
+        estimator_bwd.compute_eig()
+        estimator_bwd.plot_spectrum()
+        estimator_bwd.plot_spectrum(real_only=True)
+        estimator_bwd.plot_eig_embedding()
+        estimator_bwd.plot_eig_embedding(left=False)
 
-        mc_bwd.compute_metastable_states(use=1)
-        mc_bwd.plot_metastable_states()
+        estimator_bwd.compute_metastable_states(use=1)
+        estimator_bwd.plot_metastable_states()
 
-        mc_bwd.compute_lin_probs()
-        mc_bwd.plot_lin_probs()
+        estimator_bwd.compute_lin_probs()
+        estimator_bwd.plot_lin_probs()
 
-        mc_bwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
+        estimator_bwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
 
         _assert_has_all_keys(adata, Direction.BACKWARD)
 
@@ -154,39 +154,39 @@ class TestLowLevelPipeline:
         ck = ConnectivityKernel(adata).compute_transition_matrix()
         final_kernel = 0.8 * vk + 0.2 * ck
 
-        mc_fwd = cr.tl.GPCCA(final_kernel)
+        estimator_fwd = cr.tl.GPCCA(final_kernel)
 
-        mc_fwd.compute_partition()
+        estimator_fwd.compute_partition()
 
-        mc_fwd.compute_eig()
-        mc_fwd.plot_spectrum()
-        mc_fwd.plot_spectrum(real_only=True)
+        estimator_fwd.compute_eig()
+        estimator_fwd.plot_spectrum()
+        estimator_fwd.plot_spectrum(real_only=True)
 
-        mc_fwd.compute_schur(5, method="brandts")
-        mc_fwd.plot_schur_embedding()
+        estimator_fwd.compute_schur(5, method="brandts")
+        estimator_fwd.plot_schur_embedding()
 
-        mc_fwd.compute_metastable_states(3, n_cells=16)
-        mc_fwd.plot_metastable_states()
-        mc_fwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
-        mc_fwd.plot_schur_matrix()
+        estimator_fwd.compute_metastable_states(3, n_cells=16)
+        estimator_fwd.plot_metastable_states()
+        estimator_fwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
+        estimator_fwd.plot_schur_matrix()
 
         # select all states
-        mc_fwd.set_main_states(n_cells=16)
-        mc_fwd.plot_main_states()
+        estimator_fwd.set_main_states(n_cells=16)
+        estimator_fwd.plot_main_states()
 
-        mc_fwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
+        estimator_fwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
 
         _assert_has_all_keys(adata, Direction.FORWARD)
 
         # select a subset of states
-        mc_fwd.set_main_states(
-            n_cells=25,
-            names=self.metastable_states.cat.categories[:2],
+        estimator_fwd.set_main_states(
+            n_cells=16,
+            names=estimator_fwd.metastable_states.cat.categories[:2],
             redistribute=False,
         )
-        mc_fwd.plot_main_states()
+        estimator_fwd.plot_main_states()
 
-        mc_fwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
+        estimator_fwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
 
         _assert_has_all_keys(adata, Direction.FORWARD)
 
@@ -195,36 +195,36 @@ class TestLowLevelPipeline:
         ck = ConnectivityKernel(adata, backward=True).compute_transition_matrix()
         final_kernel = 0.8 * vk + 0.2 * ck
 
-        mc_bwd = cr.tl.GPCCA(final_kernel)
+        estimator_bwd = cr.tl.GPCCA(final_kernel)
 
-        mc_bwd.compute_eig()
-        mc_bwd.plot_spectrum()
-        mc_bwd.plot_spectrum(real_only=True)
+        estimator_bwd.compute_eig()
+        estimator_bwd.plot_spectrum()
+        estimator_bwd.plot_spectrum(real_only=True)
 
-        mc_bwd.compute_schur(5, method="brandts")
-        mc_bwd.plot_schur_embedding()
+        estimator_bwd.compute_schur(5, method="brandts")
+        estimator_bwd.plot_schur_embedding()
 
-        mc_bwd.compute_metastable_states(3, n_cells=16)
-        mc_bwd.plot_metastable_states()
-        mc_bwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
-        mc_bwd.plot_schur_matrix()
+        estimator_bwd.compute_metastable_states(3, n_cells=16)
+        estimator_bwd.plot_metastable_states()
+        estimator_bwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
+        estimator_bwd.plot_schur_matrix()
 
         # select all cells
-        mc_bwd.set_main_states(n_cells=16)
-        mc_bwd.plot_main_states()
+        estimator_bwd.set_main_states(n_cells=16)
+        estimator_bwd.plot_main_states()
 
-        mc_bwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
+        estimator_bwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
 
         _assert_has_all_keys(adata, Direction.BACKWARD)
 
         # select a subset of states
-        mc_bwd.set_main_states(
-            n_cells=25,
-            names=self.metastable_states.cat.categories[:2],
+        estimator_bwd.set_main_states(
+            n_cells=16,
+            names=estimator_bwd.metastable_states.cat.categories[:2],
             redistribute=False,
         )
-        mc_bwd.plot_main_states()
+        estimator_bwd.plot_main_states()
 
-        mc_bwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
+        estimator_bwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
 
         _assert_has_all_keys(adata, Direction.FORWARD)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -165,13 +165,13 @@ class TestLowLevelPipeline:
         mc_fwd.compute_schur(5, method="brandts")
         mc_fwd.plot_schur_embedding()
 
-        mc_fwd.compute_metastable_states(3, n_cells=25)
+        mc_fwd.compute_metastable_states(3, n_cells=16)
         mc_fwd.plot_metastable_states()
         mc_fwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
         mc_fwd.plot_schur_matrix()
 
         # select all states
-        mc_fwd.set_main_states(n_cells=25)
+        mc_fwd.set_main_states(n_cells=16)
         mc_fwd.plot_main_states()
 
         mc_fwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
@@ -204,13 +204,13 @@ class TestLowLevelPipeline:
         mc_bwd.compute_schur(5, method="brandts")
         mc_bwd.plot_schur_embedding()
 
-        mc_bwd.compute_metastable_states(3, n_cells=25)
+        mc_bwd.compute_metastable_states(3, n_cells=16)
         mc_bwd.plot_metastable_states()
         mc_bwd.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True)
         mc_bwd.plot_schur_matrix()
 
         # select all cells
-        mc_bwd.set_main_states(n_cells=25)
+        mc_bwd.set_main_states(n_cells=16)
         mc_bwd.plot_main_states()
 
         mc_bwd.compute_lineage_drivers(cluster_key="clusters", use_raw=False)


### PR DESCRIPTION
This removes the **kwargs from the 1-state case method of the gpcca estimator