### PR TITLE
Remove the metastable assignment

### DIFF
--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -887,6 +887,32 @@ class GPCCA(BaseEstimator):
         en_cutoff: Optional[float] = 0.7,
         p_thresh: float = 1e-15,
     ) -> None:
+        """Map a fuzzy clustering to pre-computed annotations to get names and colors.
+
+        Given the fuzzy clustering we have computed, we would like to select the most likely cells from each state
+        and use these to give each state a name and a color by comparing with pre-computed, categorical cluster
+        annotations.
+
+        Params
+        --------
+        memberships
+            Fuzzy clustering
+        n_cells
+            Number of cells to be used to represent each state
+        cluster_key
+            Key from `adata.obs` to get reference cluster annotations
+        en_cutoff
+            Threshold to decide when we we want to warn the user about an uncertain name mapping. This happens when
+            one fuzzy state overlaps with several reference clusters, and the most likely cells are distributed almost
+            evenly across the reference clusters.
+        p_thresh
+            Only used to detect cell cycle stages. These have to be present in `adata.obs` as `G2M_score` and `S_score`
+
+        Returns
+        --------
+        Writes a lineage object which mapped names and colors. Also creates a categorical Series
+        `self.metastable_states`, where the top `n_cells` cells represent each fuzzy state
+        """
 
         if n_cells is None:
             max_assignment = np.argmax(memberships, axis=1)

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -882,8 +882,8 @@ class GPCCA(BaseEstimator):
     def _assign_metastable_states(
         self,
         memberships: np.ndarray,
-        n_cells: Optional[int],
-        cluster_key: str,
+        n_cells: Optional[int] = 30,
+        cluster_key: str = "clusters",
         en_cutoff: Optional[float] = 0.7,
         p_thresh: float = 1e-15,
     ) -> None:

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -884,8 +884,8 @@ class GPCCA(BaseEstimator):
         memberships: np.ndarray,
         n_cells: Optional[int],
         cluster_key: str,
-        p_thresh: float,
-        en_cutoff: float,
+        en_cutoff: Optional[float] = 0.7,
+        p_thresh: float = 1e-15,
     ) -> None:
 
         if n_cells is None:

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -886,6 +886,7 @@ class GPCCA(BaseEstimator):
         cluster_key: str = "clusters",
         en_cutoff: Optional[float] = 0.7,
         p_thresh: float = 1e-15,
+        check_row_sums: bool = True,
     ) -> None:
         """Map a fuzzy clustering to pre-computed annotations to get names and colors.
 
@@ -907,6 +908,8 @@ class GPCCA(BaseEstimator):
             evenly across the reference clusters.
         p_thresh
             Only used to detect cell cycle stages. These have to be present in `adata.obs` as `G2M_score` and `S_score`
+        check_row_sums
+            Check whether rows in `memberships` sum to 1. They should.
 
         Returns
         --------
@@ -941,6 +944,7 @@ class GPCCA(BaseEstimator):
                 n_most_likely=n_cells,
                 remove_overlap=REMOVE_OVERLAP,
                 raise_threshold=0.2,
+                check_row_sums=check_row_sums,
             )
             metastable_states = _series_from_one_hot_matrix(
                 a=a_discrete, index=self.adata.obs_names


### PR DESCRIPTION
Makes that function a bit easier to call. Long term, should make this a class independent utility function anyways. 