### PR TITLE
By default, use transitions_conf

### DIFF
--- a/cellrank/plotting/_cluster_fates.py
+++ b/cellrank/plotting/_cluster_fates.py
@@ -213,7 +213,7 @@ def cluster_fates(
         kwargs["node_colors"] = colors
         kwargs.pop("save", None)  # we will handle saving
 
-        kwargs["transitions"] = kwargs.get("transitions", None)
+        kwargs["transitions"] = kwargs.get("transitions", "transitions_confidence")
         if "legend_loc" in kwargs:
             orig_ll = kwargs["legend_loc"]
             if orig_ll != "on data":


### PR DESCRIPTION
This changes the default in `cr.pl.cluster_fates` to plot a direted PAGA if PAGA has been computed using scvelo. 