### PR TITLE
Speedup for CFLARE

### DIFF
--- a/cellrank/tools/estimators/_cflare.py
+++ b/cellrank/tools/estimators/_cflare.py
@@ -578,6 +578,7 @@ class CFLARE(BaseEstimator):
         check_irred: bool = False,
         norm_by_frequ: bool = False,
         use_iterative_solver: Optional[bool] = None,
+        tol: float = 1e-5,
     ) -> None:
         """
         Compute absorption probabilities for a Markov chain.
@@ -597,6 +598,8 @@ class CFLARE(BaseEstimator):
         use_iterative_solver
             Whether to use an iterative solver for the linear system. Makes sense for large problems (> 20k cells)
             with few final states (<50)
+        tol
+            Convergence tolerance for the iterative solver
 
         Returns
         -------
@@ -696,7 +699,7 @@ class CFLARE(BaseEstimator):
         if use_iterative_solver:
 
             def flex_solve(M, B, solver):
-                X, info = zip(*(solver(M, b.toarray().flatten()) for b in B.T))
+                X, info = zip(*(solver(M, b.toarray().flatten(), tol=tol) for b in B.T))
                 return np.transpose(X), info
 
             logg.debug("DEBUG: Solving the linear system using GMRES")

--- a/cellrank/tools/estimators/_cflare.py
+++ b/cellrank/tools/estimators/_cflare.py
@@ -675,7 +675,7 @@ class CFLARE(BaseEstimator):
                 use_iterative_solver = True
             else:
                 use_iterative_solver = False
-            solver = "an interative" if use_iterative_solver else "a direct"
+        solver = "an interative" if use_iterative_solver else "a direct"
         logg.debug(
             f"DEBUG: Found {n_cells} cells and {s.shape[1]} absorbing states. Using {solver} solver"
         )

--- a/cellrank/tools/estimators/_cflare.py
+++ b/cellrank/tools/estimators/_cflare.py
@@ -599,7 +599,8 @@ class CFLARE(BaseEstimator):
             Whether to use an iterative solver for the linear system. Makes sense for large problems (> 20k cells)
             with few final states (<50)
         tol
-            Convergence tolerance for the iterative solver
+            Convergence tolerance for the iterative solver. The default is fine for most cases, only consider
+            decreasing this for severely ill-conditioned matrices.
 
         Returns
         -------

--- a/cellrank/tools/estimators/_cflare.py
+++ b/cellrank/tools/estimators/_cflare.py
@@ -676,9 +676,9 @@ class CFLARE(BaseEstimator):
             else:
                 use_iterative_solver = False
             solver = "an interative" if use_iterative_solver else "a direct"
-            logg.debug(
-                f"DEBUG: Found {n_cells} cells and {s.shape[1]} absorbing states. Using {solver} solver"
-            )
+        logg.debug(
+            f"DEBUG: Found {n_cells} cells and {s.shape[1]} absorbing states. Using {solver} solver"
+        )
 
         if not use_iterative_solver:
             logg.debug("DEBUG: Densifying matrices for direct solver ")

--- a/tests/test_cflare.py
+++ b/tests/test_cflare.py
@@ -139,26 +139,25 @@ class TestCFLARE:
         )
         np.testing.assert_allclose(mc.lineage_probabilities.X.sum(1), 1)
 
-    def test_compute_lin_probs_sparse(self, adata_large: AnnData):
+    def test_compute_lin_probs_solver(self, adata_large: AnnData):
         vk = VelocityKernel(adata_large).compute_transition_matrix()
         ck = ConnectivityKernel(adata_large).compute_transition_matrix()
         final_kernel = 0.8 * vk + 0.2 * ck
+        tol = 1e-6
 
         mc = cr.tl.CFLARE(final_kernel)
         mc.compute_eig(k=5)
         mc.compute_metastable_states(use=2)
 
-        # compute lin probs using dense routine
-        mc.compute_lin_probs()
-        l_dense = mc.lineage_probabilities
+        # compute lin probs using direct solver
+        mc.compute_lin_probs(use_iterative_solver=False)
+        l_direct = mc.lineage_probabilities
 
-        # comptue lin probs using sparse routine
-        mc.compute_lin_probs()
-        l_sparse = mc.lineage_probabilities
+        # comptue lin probs using iterative solver
+        mc.compute_lin_probs(use_iterative_solver=True, tol=tol)
+        l_iterative = mc.lineage_probabilities()
 
-        np.testing.assert_allclose(
-            l_dense.X, l_sparse.X, rtol=1e3 * EPS, atol=1e3 * EPS
-        )
+        np.testing.assert_allclose(l_direct.X, l_iterative.X, rtol=0, atol=tol)
 
     def test_compute_lineage_drivers_no_lineages(self, adata_large: AnnData):
         vk = VelocityKernel(adata_large).compute_transition_matrix()

--- a/tests/test_cflare.py
+++ b/tests/test_cflare.py
@@ -149,11 +149,11 @@ class TestCFLARE:
         mc.compute_metastable_states(use=2)
 
         # compute lin probs using dense routine
-        mc.compute_lin_probs(densify=True)
+        mc.compute_lin_probs()
         l_dense = mc.lineage_probabilities
 
         # comptue lin probs using sparse routine
-        mc.compute_lin_probs(densify=False)
+        mc.compute_lin_probs()
         l_sparse = mc.lineage_probabilities
 
         np.testing.assert_allclose(

--- a/tests/test_cflare.py
+++ b/tests/test_cflare.py
@@ -155,7 +155,7 @@ class TestCFLARE:
 
         # comptue lin probs using iterative solver
         mc.compute_lin_probs(use_iterative_solver=True, tol=tol)
-        l_iterative = mc.lineage_probabilities()
+        l_iterative = mc.lineage_probabilities
 
         np.testing.assert_allclose(l_direct.X, l_iterative.X, rtol=0, atol=tol)
 


### PR DESCRIPTION
This fixes a stupid bottleneck in the computation of abs probs which was related to selecting indices. More importantly, it enables using iterative solvers for the linear problem. So far, I'm using GMRES, but bicgstag also looked promising. The iterative solvers are powerful if the matrices are sparse, very large and I'm not computing too many absorbing cells. 