### PR TITLE
Add parallel to iterative_solver

### DIFF
--- a/cellrank/tools/estimators/_base_estimator.py
+++ b/cellrank/tools/estimators/_base_estimator.py
@@ -324,6 +324,13 @@ class BaseEstimator(ABC):
         use_initialization
             Only relevant when using an iterative solver. In that case, the solution of absorbing states from the same
             recurrent class can be used as initialization to the iterative solver.
+        n_jobs
+            Number of parallel jobs. If `-1`, use all available cores. If `None` or `1`, the execution is sequential.
+        backend
+            Which backend to use for multiprocessing. Only used when :paramref:`n_jobs` `!=1`.
+            See :class:`joblib.Parallel` for valid options.
+        show_progress_bar
+            Whether to show a progress bar tracking. Only used when :paramref:`n_jobs` `!=1`.
 
         Returns
         -------

--- a/cellrank/tools/estimators/_base_estimator.py
+++ b/cellrank/tools/estimators/_base_estimator.py
@@ -16,23 +16,22 @@ from typing import (
 )
 from pathlib import Path
 
-import numpy as np
-import scipy
-import pandas as pd
-from pandas import Series
-from scipy.stats import entropy, ranksums
-from scipy.linalg import solve
-from scipy.sparse import issparse, spmatrix, csr_matrix
-from pandas.api.types import infer_dtype, is_categorical_dtype
-from scipy.sparse.linalg import eigs, gmres
-
 import matplotlib as mpl
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 
 import scvelo as scv
 
+import numpy as np
+import scipy
+import pandas as pd
+from pandas import Series
 from cellrank import logging as logg
+from scipy.stats import entropy, ranksums
+from scipy.linalg import solve
+from scipy.sparse import issparse, spmatrix, csr_matrix
+from pandas.api.types import infer_dtype, is_categorical_dtype
+from scipy.sparse.linalg import eigs, gmres
 from cellrank.tools._utils import (
     save_fig,
     _eigengap,
@@ -438,11 +437,7 @@ class BaseEstimator(ABC):
                 for ix, b in enumerate(B.T):
                     # use the previous problem solution as initialisation
                     if init_indices is not None:
-                        x0 = (
-                            None
-                            if (init_indices is not None and ix in init_indices)
-                            else x
-                        )
+                        x0 = None if ix in init_indices else x
                     else:
                         x0 = None
                     x, info = solver(M, b.toarray().flatten(), tol=tol, x0=x0)

--- a/cellrank/utils/_parallelize.py
+++ b/cellrank/utils/_parallelize.py
@@ -7,6 +7,7 @@ from multiprocessing import Manager
 
 import numpy as np
 import joblib as jl
+from scipy.sparse import issparse, spmatrix
 
 from cellrank.utils._utils import _get_n_cores
 
@@ -15,7 +16,7 @@ _msg_shown = False
 
 def parallelize(
     callback: Callable[[Any], Any],
-    collection: Sequence[Any],
+    collection: Union[spmatrix, Sequence[Any]],
     n_jobs: Optional[int] = None,
     n_split: Optional[int] = None,
     unit: str = "",
@@ -83,7 +84,21 @@ def parallelize(
     def update(pbar, queue, n_total):
         n_finished = 0
         while n_finished < n_total:
-            if queue.get() is None:
+            try:
+                res = queue.get()
+            except EOFError:
+                if not n_finished != n_total:
+                    raise RuntimeError(
+                        f"Received `EOFError`, but only finished `{n_finished} out of `{n_total}` tasks.`"
+                    )
+                print("x")
+                break
+            assert res in (None, (1, None), 1)  # (None, 1) means only 1 job
+            if res == (1, None):
+                n_finished += 1
+                if pbar is not None:
+                    pbar.update()
+            elif res is None:
                 n_finished += 1
             elif pbar is not None:
                 pbar.update()
@@ -92,10 +107,10 @@ def parallelize(
             pbar.close()
 
     def wrapper(*args, **kwargs):
-        pbar = None if tqdm is None else tqdm(total=len(collection), unit=unit)
+        pbar = None if tqdm is None else tqdm(total=col_len, unit=unit)
 
         queue = Manager().Queue()
-        thread = Thread(target=update, args=(pbar, queue, len(collections)))
+        thread = Thread(target=update, args=(pbar, queue, col_len))
         thread.start()
 
         res = jl.Parallel(n_jobs=n_jobs, backend=backend)(
@@ -110,9 +125,27 @@ def parallelize(
 
         return res if extractor is None else extractor(res)
 
-    n_jobs = _get_n_cores(n_jobs, len(collection))
+    col_len = collection.shape[0] if issparse(collection) else len(collection)
+    n_jobs = _get_n_cores(n_jobs, col_len)
     if n_split is None:
         n_split = n_jobs
-    collections = list(filter(len, np.array_split(collection, n_split)))
+
+    if issparse(collection):
+        if n_split == collection.shape[0]:
+            collections = [collection[[ix], :] for ix in range(collection.shape[0])]
+        else:
+            step = collection.shape[0] // n_split
+
+            ixs = [
+                np.arange(i * step, min((i + 1) * step, collection.shape[0]))
+                for i in range(n_split)
+            ]
+            ixs[-1] = np.append(
+                ixs[-1], np.arange(ixs[-1][-1] + 1, collection.shape[0])
+            )
+
+            collections = [collection[ix, :] for ix in filter(len, ixs)]
+    else:
+        collections = list(filter(len, np.array_split(collection, n_split)))
 
     return wrapper

--- a/cellrank/utils/_parallelize.py
+++ b/cellrank/utils/_parallelize.py
@@ -91,7 +91,6 @@ def parallelize(
                     raise RuntimeError(
                         f"Received `EOFError`, but only finished `{n_finished} out of `{n_total}` tasks.`"
                     )
-                print("x")
                 break
             assert res in (None, (1, None), 1)  # (None, 1) means only 1 job
             if res == (1, None):
@@ -110,7 +109,7 @@ def parallelize(
         pbar = None if tqdm is None else tqdm(total=col_len, unit=unit)
 
         queue = Manager().Queue()
-        thread = Thread(target=update, args=(pbar, queue, col_len))
+        thread = Thread(target=update, args=(pbar, queue, len(collections)))
         thread.start()
 
         res = jl.Parallel(n_jobs=n_jobs, backend=backend)(


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
Parallelize solving of the system when computing absorption probabilities.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Clearly and concisely describe your changes. -->
Added an option to solve the system in parallel, default is still sequential.

## How has this been tested?
No unit tests yet - I will add one test using parallel option.

##Benchmarking
For now, only on pancres, 20 lineages.
Before:
1.12 s ± 23.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
After:
954 ms ± 14.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

## Closes
closes #256 

@Marius1311 
There was previously this line: `x0 = None if ix in init_indices else x`, but it doesn't seem correct: https://github.com/theislab/cellrank/blob/master/cellrank/tools/estimators/_base_estimator.py#L419. Am I wrong?
``` 
