### PR TITLE
Add PETSc solver

### DIFF
--- a/cellrank/plotting/_gene_trend.py
+++ b/cellrank/plotting/_gene_trend.py
@@ -6,12 +6,11 @@ from types import MappingProxyType
 from typing import Tuple, Union, Mapping, TypeVar, Optional, Sequence
 from pathlib import Path
 
-import numpy as np
-
 import matplotlib
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 
+import numpy as np
 from cellrank import logging as logg
 from cellrank.tools._utils import save_fig
 from cellrank.utils._utils import _get_n_cores, _make_unique, check_collection
@@ -150,8 +149,7 @@ def gene_trends(
     n_jobs
         Number of parallel jobs. If `-1`, use all available cores. If `None` or `1`, the execution is sequential.
     backend
-        Which backend to use for multiprocessing.
-        See :class:`joblib.Parallel` for valid options.
+        Which backend to use for multiprocessing. See :class:`joblib.Parallel` for valid options.
     ext
         Extension to use when saving files, such as `'pdf'`.
         Only used when :paramref:`same_plot` `=False`.

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -17,12 +17,9 @@ from typing import (
 )
 from itertools import tee, product, combinations
 
-import matplotlib.colors as mcolors
-
 import numpy as np
 import pandas as pd
 from pandas import Series
-from cellrank import logging as logg
 from numpy.linalg import norm as d_norm
 from scipy.linalg import solve
 from scipy.sparse import eye as speye
@@ -39,6 +36,10 @@ from pandas.api.types import infer_dtype, is_categorical_dtype
 from sklearn.neighbors import NearestNeighbors
 from scipy.sparse.linalg import norm as s_norm
 from scipy.sparse.linalg import gmres, lgmres, gcrotmk, bicgstab
+
+import matplotlib.colors as mcolors
+
+from cellrank import logging as logg
 from cellrank.utils._utils import (
     _get_neighs,
     _has_neighs,
@@ -1509,7 +1510,7 @@ def _solve_lin_system(
     mat_a: Union[np.ndarray, spmatrix],
     mat_b: Union[np.ndarray, spmatrix],
     solver: str = _DEFAULT_SOLVER,
-    use_petsc: bool = True,
+    use_petsc: bool = False,
     preconditioner: Optional[str] = None,
     n_jobs: Optional[int] = None,
     backend: str = "multiprocessing",

--- a/cellrank/tools/_utils.py
+++ b/cellrank/tools/_utils.py
@@ -1566,15 +1566,16 @@ def _solve_lin_system(
         defined via columns in `mat_b`.
     """
 
-    try:
-        from petsc4py import PETSc  # noqa
-    except ImportError:
-        global _PETSC_ERROR_MSG_SHOWN
-        if not _PETSC_ERROR_MSG_SHOWN:
-            _PETSC_ERROR_MSG_SHOWN = True
-            print(_PETSC_ERROR_MSG.format(_DEFAULT_SOLVER))
-        solver = _DEFAULT_SOLVER
-        use_petsc = False
+    if use_petsc:
+        try:
+            from petsc4py import PETSc  # noqa
+        except ImportError:
+            global _PETSC_ERROR_MSG_SHOWN
+            if not _PETSC_ERROR_MSG_SHOWN:
+                _PETSC_ERROR_MSG_SHOWN = True
+                print(_PETSC_ERROR_MSG.format(_DEFAULT_SOLVER))
+            solver = _DEFAULT_SOLVER
+            use_petsc = False
 
     if use_petsc:
         if not isspmatrix_csr(mat_a):

--- a/cellrank/tools/estimators/_base_estimator.py
+++ b/cellrank/tools/estimators/_base_estimator.py
@@ -454,12 +454,15 @@ class BaseEstimator(ABC):
             abs_classes, names=self._lin_probs.names, colors=self._lin_probs.colors,
         )
 
-        self._adata.obsm[self._lin_key] = self._lin_probs
-        self._adata.obs[_dp(self._lin_key)] = self._dp = self._lin_probs.entropy(
+        self.adata.obsm[self._lin_key] = self._lin_probs
+
+        self.adata.obs[_dp(self._lin_key)] = self._lin_probs.entropy(axis=1).X.squeeze(
             axis=1
-        ).X.squeeze(axis=1)
-        self._adata.uns[_lin_names(self._lin_key)] = self._lin_probs.names
-        self._adata.uns[_colors(self._lin_key)] = self._lin_probs.colors
+        )
+        self._dp = self.adata.obs[_dp(self._lin_key)]  # make it a pd.Series
+
+        self.adata.uns[_lin_names(self._lin_key)] = self._lin_probs.names
+        self.adata.uns[_colors(self._lin_key)] = self._lin_probs.colors
 
         logg.info("    Finish", time=start)
 
@@ -1099,7 +1102,7 @@ class BaseEstimator(ABC):
         return self._eig
 
     @property
-    def diff_potential(self) -> np.ndarray:
+    def diff_potential(self) -> pd.Series:
         """Differentiation potential for each lineage."""  # noqa
         return self._dp
 

--- a/cellrank/tools/estimators/_base_estimator.py
+++ b/cellrank/tools/estimators/_base_estimator.py
@@ -106,6 +106,9 @@ class BaseEstimator(ABC):
 
         self._lin_probs = None
 
+        self._meta_states = None
+        self._meta_states_colors = None
+
         # for copy
         self._g2m_key = g2m_key
         self._s_key = s_key

--- a/cellrank/tools/estimators/_base_estimator.py
+++ b/cellrank/tools/estimators/_base_estimator.py
@@ -5,20 +5,21 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Tuple, Union, TypeVar, Iterable, Optional, Sequence
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
+from pandas import Series
+from scipy.stats import ranksums
+from scipy.sparse import issparse
+from pandas.api.types import infer_dtype, is_categorical_dtype
+from scipy.sparse.linalg import eigs
+
 import matplotlib as mpl
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 
 import scvelo as scv
 
-import numpy as np
-import pandas as pd
-from pandas import Series
 from cellrank import logging as logg
-from scipy.stats import ranksums
-from scipy.sparse import issparse
-from pandas.api.types import infer_dtype, is_categorical_dtype
-from scipy.sparse.linalg import eigs
 from cellrank.tools._utils import (
     save_fig,
     _eigengap,
@@ -283,7 +284,7 @@ class BaseEstimator(ABC):
         keys: Optional[Sequence[str]] = None,
         check_irred: bool = False,
         solver: Optional[str] = None,
-        use_petsc: bool = True,
+        use_petsc: bool = False,
         preconditioner: Optional[str] = None,
         n_jobs: Optional[int] = None,
         backend: str = "multiprocessing",

--- a/cellrank/tools/estimators/_base_estimator.py
+++ b/cellrank/tools/estimators/_base_estimator.py
@@ -287,7 +287,7 @@ class BaseEstimator(ABC):
         use_petsc: Optional[bool] = None,
         preconditioner: Optional[str] = None,
         n_jobs: Optional[int] = None,
-        backend: str = "multiprocessing",
+        backend: str = "loky",
         tol: float = 1e-5,
     ) -> None:
         """
@@ -305,21 +305,23 @@ class BaseEstimator(ABC):
             Check whether the transition matrix is irreducible.
         solver
             Solver to use for the linear problem. Options are `['direct', 'gmres', 'lgmres', 'bicgstab', 'gcrotmk']`
-            when :paramref:`use_petsc` or one of `petsc4py.PETSc.KPS.Type` otherwise.
+            when :paramref:`use_petsc` `=False` or one of `petsc4py.PETSc.KPS.Type` otherwise.
 
             Information on the :module:`scipy` iterative solvers can be found in :func:`scipy.sparse.linalg` or
             for the :module:`petsc4py` solver in https://www.mcs.anl.gov/petsc/documentation/linearsolvertable.html.
 
-            If is `None`, a solver is chosen automatically, depending on the current problem.
+            If is `None`, solver is chosen automatically, depending on the current problem.
         use_petsc
-            Whether to use solvers from :module:`petsc4py` instead of :module:`scipy`. Recommended for large problems.
-            If `None`, it is determined automatically.
+            Whether to use solvers from :module:`petsc4py` or :module:`scipy`. Recommended for large problems.
+            If `None`, it is determined automatically. If no installation is found, defaults
+            to :func:`scipy.sparse.linalg.gmres`.
         preconditioner
             Preconditioner to use when :paramref:`use_petsc` `=True`.
             For available preconditioner types, see `petsc4py.PETSc.PC.Type`.
         n_jobs
-            Number of parallel jobs to use when :paramref:`use_petsc` `=True`. For small, quickly-solvable problems,
-            we recommend high number (>=8) of cores in order to fully saturate them.
+            Number of parallel jobs to use when using an iterative solver.
+            When :paramref:`use_petsc` `=True` or for quickly-solvable problems,
+            we recommend higher number (>=4) of jobs in order to fully saturate the cores.
         backend
             Which backend to use for multiprocessing. See :class:`joblib.Parallel` for valid options.
         tol
@@ -967,7 +969,7 @@ class BaseEstimator(ABC):
         # check that lineage probs have been computed
         if self._lin_probs is None:
             raise RuntimeError(
-                "Compute lineage probabilities first as `.compute_absorption_probabilities()` or `.set_main_states`."
+                "Compute lineage probabilities first as `.compute_absorption_probabilities()` or `.set_main_states()`."
             )
 
         # check all lin_keys exist in self.lin_names

--- a/cellrank/tools/estimators/_gppca.py
+++ b/cellrank/tools/estimators/_gppca.py
@@ -6,10 +6,6 @@ from types import MappingProxyType
 from typing import Any, Dict, List, Tuple, Union, Mapping, TypeVar, Iterable, Optional
 from pathlib import Path
 
-import numpy as np
-import pandas as pd
-from scipy.stats import entropy
-
 import matplotlib as mpl
 import matplotlib.cm as cm
 import matplotlib.colors as mcolors
@@ -18,7 +14,10 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 import scvelo as scv
 
+import numpy as np
+import pandas as pd
 from cellrank import logging as logg
+from scipy.stats import entropy
 from cellrank.tools._utils import (
     save_fig,
     _eigengap,
@@ -36,9 +35,8 @@ from cellrank._vendor.msmtools.analysis.dense.gpcca import GPCCA as _GPCCA
 
 AnnData = TypeVar("AnnData")
 
-
 # whether to remove overlapping cells from both states, or assign them to the most likely clusters
-REMOVE_OVERLAP = False
+_REMOVE_OVERLAP = False
 
 
 class GPCCA(BaseEstimator):
@@ -94,8 +92,6 @@ class GPCCA(BaseEstimator):
         self._coarse_init_dist = None
         self._coarse_stat_dist = None
 
-        self._meta_states = None
-        self._meta_states_colors = None
         self._meta_lin_probs = None
 
         self._main_states = None
@@ -680,7 +676,7 @@ class GPCCA(BaseEstimator):
         a_discrete, _ = _fuzzy_to_discrete(
             a_fuzzy=probs,
             n_most_likely=n_cells,
-            remove_overlap=REMOVE_OVERLAP,
+            remove_overlap=_REMOVE_OVERLAP,
             raise_threshold=0.2,
             check_row_sums=False,
         )
@@ -945,7 +941,7 @@ class GPCCA(BaseEstimator):
             a_discrete, not_enough_cells = _fuzzy_to_discrete(
                 a_fuzzy=memberships,
                 n_most_likely=n_cells,
-                remove_overlap=REMOVE_OVERLAP,
+                remove_overlap=_REMOVE_OVERLAP,
                 raise_threshold=0.2,
                 check_row_sums=check_row_sums,
             )

--- a/cellrank/utils/_parallelize.py
+++ b/cellrank/utils/_parallelize.py
@@ -86,11 +86,11 @@ def parallelize(
         while n_finished < n_total:
             try:
                 res = queue.get()
-            except EOFError:
+            except EOFError as e:
                 if not n_finished != n_total:
                     raise RuntimeError(
-                        f"Received `EOFError`, but only finished `{n_finished} out of `{n_total}` tasks.`"
-                    )
+                        f"Finished only `{n_finished} out of `{n_total}` tasks.`"
+                    ) from e
                 break
             assert res in (None, (1, None), 1)  # (None, 1) means only 1 job
             if res == (1, None):

--- a/cellrank/utils/_utils.py
+++ b/cellrank/utils/_utils.py
@@ -5,9 +5,8 @@ from typing import Any, Dict, List, Tuple, Union, TypeVar, Hashable, Iterable, O
 from multiprocessing import cpu_count
 
 import numpy as np
-from scipy.sparse import spmatrix
-
 from cellrank import logging as logg
+from scipy.sparse import spmatrix
 
 AnnData = TypeVar("AnnData")
 
@@ -39,7 +38,7 @@ def check_collection(
             raise KeyError(f"{key_name} `{needle}` not found in `adata.{attr_name}`.")
 
 
-def _get_n_cores(n_cores: Optional[int], n_genes: int) -> int:
+def _get_n_cores(n_cores: Optional[int], n_jobs: Optional[int]) -> int:
     """
     Make number of cores a positive integer.
 
@@ -58,7 +57,7 @@ def _get_n_cores(n_cores: Optional[int], n_genes: int) -> int:
 
     if n_cores == 0:
         raise ValueError("Number of cores cannot be `0`.")
-    if n_genes == 1 or n_cores is None:
+    if n_jobs == 1 or n_cores is None:
         return 1
     if n_cores < 0:
         return cpu_count() + 1 + n_cores

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ def _create_cflare(*, backward: bool = False) -> Tuple[AnnData, CFLARE]:
     mc.compute_partition()
     mc.compute_eig()
     mc.compute_metastable_states(use=2)
-    mc.compute_absorption_probabilities()
+    mc.compute_absorption_probabilities(use_petsc=False)
     mc.compute_lineage_drivers(cluster_key="clusters", use_raw=False)
 
     assert adata is mc.adata

--- a/tests/test_gpcca.py
+++ b/tests/test_gpcca.py
@@ -78,7 +78,7 @@ def _check_main_states(mc: cr.tl.GPCCA, has_main_states: bool = True):
             mc.lineage_probabilities[list(mc.main_states.cat.categories)].colors,
         )
 
-    assert isinstance(mc.diff_potential, np.ndarray)
+    assert isinstance(mc.diff_potential, pd.Series)
     assert isinstance(mc.lineage_probabilities, cr.tl.Lineage)
     np.testing.assert_array_almost_equal(mc.lineage_probabilities.sum(1), 1.0)
 


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
Add PETSc linear solver to solve the equations for lineage absorption probabilities.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)

## Description
On the server, the scipy method didn't finish in 3 hours for 100k+ cells, 3 states. If we really want to use abs. probs.
instead of GPCCA vectors, we need to speed it up. I haven't benchmarked this on the server (still queuing...), but look promising on pancreas:
337 ms ± 15.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

## How has this been tested?
I've added 1 test function which compares `gmres` from scipy and petsc.

## Closes
closes #260 

## TODOs
- [x] run on large data (lung + on the server):
- lung: 0:02:48
- lung with 4 parallel jobs (total of 150 systems, as above): 01:23
- server data: 05:33 (16 cores, 4 parallel jobs)
- [x] properly expose parameters (I just did this as a proof of concept)
- [x] tests (still mainain the old method, because PETSc is not in our reqs.txt)
