### PR TITLE
Abs time moments

### DIFF
--- a/cellrank/tl/_linear_solver.py
+++ b/cellrank/tl/_linear_solver.py
@@ -423,15 +423,13 @@ def _solve_lin_system(
             use_petsc = False
 
     if use_eye:
-        if issparse(mat_a):
-            mat_a = speye(mat_a.shape[0]) - mat_a
-        else:
-            mat_a = np.eye(mat_a.shape[0]) - mat_a
+        mat_a = (
+            speye(mat_a.shape[0]) if issparse(mat_a) else np.eye(mat_a.shape[0])
+        ) - mat_a
 
     if solver == "direct" or n_jobs == 1:
-        logg.debug("Solving the linear system using direct matrix factorization")
-
         if use_petsc:
+            logg.debug("Solving the linear system directly using `PETSc`")
             return _petsc_mat_solve(
                 mat_a, mat_b, solver=solver, preconditioner=preconditioner, tol=tol
             )
@@ -442,6 +440,8 @@ def _solve_lin_system(
         if issparse(mat_b):
             logg.debug("Densifying `B` for scipy direct solver")
             mat_b = mat_b.toarray()
+
+        logg.debug("Solving the linear system directly using `scipy`")
 
         return solve(mat_a, mat_b)
 

--- a/cellrank/tl/estimators/_base_estimator.py
+++ b/cellrank/tl/estimators/_base_estimator.py
@@ -430,6 +430,7 @@ class BaseEstimator(LineageEstimatorMixin, Partitioner, ABC):
             ),
         )
 
+        extra_msg = ""
         if pt is not None:
             self._set(A.ABS_PT, pd.Series(pt, index=self.adata.obs.index))
             self.adata.obs["absorption_pseudotime"] = pt

--- a/cellrank/tl/estimators/_constants.py
+++ b/cellrank/tl/estimators/_constants.py
@@ -24,8 +24,8 @@ class A(PrettyEnum):
     COARSE_T = "_coarse_T"
     COARSE_INIT_D = "_coarse_init_dist"
     COARSE_STAT_D = "_coarse_stat_dist"
-    MEAN_ABS_TIME = "_mean_abs_time"
-    VAR_ABS_TIME = "_var_abs_time"
+    ABS_PT = "_mean_abs_time"
+    ABS_PT_UNCERT = "_abs_pt_uncert"
     LIN_DRIVERS = "_lin_drivers"
 
 
@@ -47,8 +47,8 @@ class P(PrettyEnum):
     COARSE_T = "coarse_T"
     COARSE_INIT_D = "coarse_initial_distribution"
     COARSE_STAT_D = "coarse_stationary_distribution"
-    MEAN_ABS_TIME = "absorption_time"
-    VAR_ABS_TIME = "absorption_time_variance"
+    ABS_PT = "absorption_pseudotime"
+    ABS_PT_UNCERT = "absorption_pseudotime_uncertainty"
     LIN_DRIVERS = "lineage_drivers"
 
 

--- a/cellrank/tl/estimators/_property.py
+++ b/cellrank/tl/estimators/_property.py
@@ -757,8 +757,8 @@ class AbsProbs(Plottable):
             dtype=pd.Series,
             doc="Differentiation potential.",
         ),
-        Metadata(attr=A.MEAN_ABS_TIME, prop=P.MEAN_ABS_TIME, dtype=pd.Series),
-        Metadata(attr=A.VAR_ABS_TIME, prop=P.VAR_ABS_TIME, dtype=pd.Series),
+        Metadata(attr=A.ABS_PT, prop=P.ABS_PT, dtype=pd.Series),
+        Metadata(attr=A.ABS_PT_UNCERT, prop=P.ABS_PT_UNCERT, dtype=pd.Series),
     ]
 
     @abstractmethod


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
<!--- Provide a general summary of your changes in the Title above -->
Add more efficient computation of variance of time to absorption.
@Marius1311 I've settled on this, feel free to suggest otherwise:
- writing `'absorption_pseudotime'` and `'absorption_pseudotime_uncert'` to `adata.obs` + to `Estimator objcect` (previously were written only to estimator I think)
- I've kept the time 'til absorption + variance hidden under `_absorption_time_mean` and `_absorption_time_var` respectively

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Clearly and concisely describe your changes. -->
+ some improvements to logging.

## How has this been tested?
<!--- Describe in detail how you've tested your changes. -->
I will add test later today which uses the normal equation.

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
#closes #308 
