### PR TITLE
Expose the n_jobs parameter in the transition matrix function

### DIFF
--- a/cellrank/tl/_transition_matrix.py
+++ b/cellrank/tl/_transition_matrix.py
@@ -23,9 +23,10 @@ def transition_matrix(
     mode: str = VelocityMode.DETERMINISTIC.s,
     backward_mode: str = BackwardMode.TRANSPOSE.s,
     seed: Optional[int] = None,
-    softmax_scale: int = 4.0,
+    softmax_scale: Optional[float] = 4.0,
     weight_connectivities: Optional[float] = None,
     density_normalize: bool = True,
+    n_jobs: Optional[int] = None,
 ) -> KernelExpression:
     """
     Compute a transition matrix based on a combination of RNA Velocity and transcriptomic similarity.
@@ -50,12 +51,15 @@ def transition_matrix(
     seed
         Set the seed for random state, only used when sampling.
     softmax_scale
-        Scaling parameter for the softmax.
+        Scaling parameter for the softmax. If `None`, it will be estimated using 1/median(correlations). The idea
+        behind this is to scale the softmax to counteract everythin tending to orthogonality in high dimensions.
     weight_connectivities
         Weight given to transcriptomic similarities as opposed to velocities. Must be in `[0, 1]`.
     density_normalize
         Whether to use density correction when computing the transition probabilities based on connectivities.
         Density correction is done as by [Haghverdi16]_.
+    n_jobs
+        Number of parallel jobs. If `-1`, use all available cores. If `None` or `1`, the execution is sequential.
 
     Returns
     -------
@@ -68,7 +72,11 @@ def transition_matrix(
         adata, backward=backward, vkey=vkey, xkey=xkey, gene_subset=gene_subset
     )
     vk.compute_transition_matrix(
-        softmax_scale=softmax_scale, mode=mode, backward_mode=backward_mode, seed=seed
+        softmax_scale=softmax_scale,
+        mode=mode,
+        backward_mode=backward_mode,
+        seed=seed,
+        n_jobs=n_jobs,
     )
 
     if weight_connectivities is not None:

--- a/cellrank/tl/kernels/_velocity_kernel.py
+++ b/cellrank/tl/kernels/_velocity_kernel.py
@@ -184,7 +184,8 @@ class VelocityKernel(Kernel):
         %(velocity_mode)s
         %(velocity_backward_mode)s
         softmax_scale
-            Scaling parameter for the softmax. If `None`, it will be estimated using TODO.
+            Scaling parameter for the softmax. If `None`, it will be estimated using 1/median(correlations). The idea
+            behind this is to scale the softmax to counteract everythin tending to orthogonality in high dimensions.
         n_samples
             Number of bootstrap samples when :paramref:`mode` is `{m.MONTE_CARLO.s!r}` or `{m.PROPAGATION.s!r}`.
         seed
@@ -192,7 +193,7 @@ class VelocityKernel(Kernel):
         use_numba
             Use :mod:`numba` optimized functions. Only available if `:paramref:`mode` != `{m.STOCHASTIC.s!r}`.
             If `True`, the outermost loop is also :mod:`numba` optimized. This options disables the progress bar.
-            If `False`, the outermost loop is not optimized, but the workload is split among multiple cors.
+            If `False`, the outermost loop is not optimized, but the workload is split among multiple cores.
             If `None`, it's same as `True`, but the work is being split and each worker uses optimized outermost loop.
         %(parallel)s
 


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
Minor: expose the n_jobs parameter

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Allow the user to specify the number of cores for transition matrix comptuation in high level mode. 

## How has this been tested?
I haven't added any new tests. 

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
