### PR TITLE
Lineage absorption time

### DIFF
--- a/cellrank/tl/_linear_solver.py
+++ b/cellrank/tl/_linear_solver.py
@@ -331,7 +331,7 @@ def _petsc_mat_solve(
     res = np.array(x.getDenseArray(), copy=True)
 
     if not ksp.converged:
-        logg.warning(
+        logg.debug(
             f"The solution for system "
             f"`A{list(A.getSize())} * X{list(x.getSize())} = B{list(B.getSize())}` "
             f"did not converge"

--- a/cellrank/tl/_utils.py
+++ b/cellrank/tl/_utils.py
@@ -1605,7 +1605,7 @@ def _calculate_absorption_time_moments(
     if calculate_variance:
         logg.debug("Calculating variance of time to absorption")
 
-        I = speye(q.shape[0])  # noqa
+        I = speye(q.shape[0]) if issparse(q) else np.eye(q.shape[0])  # noqa
         A_t = (I + q).T
         B_t = (I - q).T
 
@@ -1636,6 +1636,33 @@ def _calculate_lineage_absorption_time_means(
     lineages: Dict[str, str],
     **kwargs,
 ) -> pd.DataFrame:
+    """
+    Calculate the mean time until absorption and optionally its variance for specific lineages or their combinations.
+
+    Parameters
+    ----------
+    Q
+        Transient-transient submatrix of the transition matrix.
+    R
+        Transient-recurrent submatrix of the transition matrix.
+    trans_indices
+        Transient indices.
+    n
+        Number of states of the full transition matrix.
+    ixs
+        Mapping of names of absorbing states and their indices in the full transition matrix.
+    lineages
+        Lineages for which to calculate the mean time until absorption moments.
+    **kwargs
+        Keyword arguments for :func:`cellrank.tl._lin_solver._solver_lin_system`.
+
+    Returns
+    -------
+    :class:`pandas.DataFrame`
+        A dataframe with means and optionally variances of mean time to absorption for each lineage
+        in :paramref:`lineages`.
+    """
+
     for ln in lineages.keys():
         if ln not in ixs.keys():
             raise ValueError(
@@ -1649,7 +1676,7 @@ def _calculate_lineage_absorption_time_means(
         tmp_ixs[k] = np.arange(cnt, cnt + len(ix), dtype=np.int32)
         cnt += len(ix)
 
-    I = speye(Q.shape[0])  # noqa
+    I = speye(Q.shape[0]) if issparse(Q) else np.eye(Q.shape)  # noqa
     N_inv = I - Q
 
     logg.debug("Solving equation for `B`")

--- a/cellrank/tl/estimators/_base_estimator.py
+++ b/cellrank/tl/estimators/_base_estimator.py
@@ -232,7 +232,7 @@ class BaseEstimator(LineageEstimatorMixin, Partitioner, ABC):
         solver: Optional[str] = None,
         use_petsc: Optional[bool] = None,
         absorption_pseudotime: Optional[str] = None,
-        lineage_absorption_times: Optional[Union[str, Sequence[str]]] = None,
+        time_to_absorption: Optional[Union[str, Sequence[str]]] = None,
         n_jobs: Optional[int] = None,
         backend: str = "loky",
         show_progress_bar: bool = True,
@@ -266,7 +266,7 @@ class BaseEstimator(LineageEstimatorMixin, Partitioner, ABC):
         absorption_pseudotime
             Whether to compute pseudotime based on mean time to absorption to all absorbing states and its variance.
             Valid options are `None`, `'first'`, `'second'`.
-        lineage_absorption_times
+        time_to_absorption
             Whether to compute mean time to absorption and its variance for specific absorbing states.
             Can be specified as `'{{lineage}}:var'` to also calculate the variance.
             It might be beneficial to disable the progress bar as :paramref:`show_progress_bar` `=False`, because
@@ -296,7 +296,7 @@ class BaseEstimator(LineageEstimatorMixin, Partitioner, ABC):
                   Only available if :paramref:`absorption_time_moments` is `'second'`.
                 - :paramref:`{lat}` - times until absorption to individual absorbing states and optionally
                   their variances saved as `'{{lineage}}_mean'` and `'{{lineage}}_var'`, respectively,
-                  for each lineage specified in ``lineage_absorption_times``.
+                  for each lineage specified in ``time_to_absorption``.
         """
 
         if self._get(P.FIN) is None:
@@ -327,11 +327,11 @@ class BaseEstimator(LineageEstimatorMixin, Partitioner, ABC):
             series=self._get(P.FIN), keys=keys, colors=self._get(A.FIN_COLORS)
         )
 
-        if lineage_absorption_times is not None:
-            if isinstance(lineage_absorption_times, str):
-                lineage_absorption_times = [lineage_absorption_times]
+        if time_to_absorption is not None:
+            if isinstance(time_to_absorption, str):
+                time_to_absorption = [time_to_absorption]
             lin_abs_times = {}
-            for ln in lineage_absorption_times:
+            for ln in time_to_absorption:
                 ln, moment = ln.split(":") if ":" in ln else (ln, "mean")
                 if moment not in ("mean", "var"):
                     raise ValueError(
@@ -431,7 +431,7 @@ class BaseEstimator(LineageEstimatorMixin, Partitioner, ABC):
             )
 
         abs_time_means = None
-        if lineage_absorption_times is not None:
+        if time_to_absorption is not None:
             abs_time_means = _calculate_lineage_absorption_time_means(
                 q,
                 t[trans_indices, :][:, rec_indices],

--- a/cellrank/tl/estimators/_base_estimator.py
+++ b/cellrank/tl/estimators/_base_estimator.py
@@ -426,6 +426,7 @@ class BaseEstimator(LineageEstimatorMixin, Partitioner, ABC):
                 backend=backend,
                 tol=tol,
                 show_progress_bar=show_progress_bar,
+                calculate_variance=absorption_time_moments == "second",
             )
             self._atm = mean2
 

--- a/cellrank/tl/estimators/_constants.py
+++ b/cellrank/tl/estimators/_constants.py
@@ -26,6 +26,7 @@ class A(PrettyEnum):
     COARSE_STAT_D = "_coarse_stat_dist"
     ABS_PT = "_abs_pt"
     ABS_PT_VAR = "_abs_pt_var"
+    LIN_ABS_TIMES = "_lin_abs_times"
     LIN_DRIVERS = "_lin_drivers"
 
 
@@ -49,6 +50,7 @@ class P(PrettyEnum):
     COARSE_STAT_D = "coarse_stationary_distribution"
     ABS_PT = "absorption_pseudotime"
     ABS_PT_VAR = "absorption_pseudotime_variance"
+    LIN_ABS_TIMES = "lineage_absorption_times"
     LIN_DRIVERS = "lineage_drivers"
 
 

--- a/cellrank/tl/estimators/_property.py
+++ b/cellrank/tl/estimators/_property.py
@@ -765,6 +765,7 @@ class AbsProbs(Plottable):
         ),
         Metadata(attr=A.ABS_PT, prop=P.ABS_PT, dtype=pd.Series),
         Metadata(attr=A.ABS_PT_VAR, prop=P.ABS_PT_VAR, dtype=pd.Series),
+        Metadata(attr=A.LIN_ABS_TIMES, prop=P.LIN_ABS_TIMES, dtype=pd.DataFrame),
     ]
 
     @abstractmethod

--- a/tests/test_cflare.py
+++ b/tests/test_cflare.py
@@ -199,7 +199,7 @@ class TestCFLARE:
 
         # compute lin probs using direct solver
         mc.compute_absorption_probabilities(
-            solver="gmres", use_petsc=False, tol=tol, absorption_time_moments="first"
+            solver="gmres", use_petsc=False, tol=tol, absorption_pseudotime="first"
         )
         pt = mc._get(P.ABS_PT)
 
@@ -223,7 +223,7 @@ class TestCFLARE:
 
         # compute lin probs using direct solver
         mc.compute_absorption_probabilities(
-            solver="gmres", use_petsc=False, tol=tol, absorption_time_moments="second"
+            solver="gmres", use_petsc=False, tol=tol, absorption_pseudotime="second"
         )
         pt = mc._get(P.ABS_PT)
         ptv = mc._get(P.ABS_PT_VAR)

--- a/tests/test_cflare.py
+++ b/tests/test_cflare.py
@@ -185,9 +185,7 @@ class TestCFLARE:
         assert not np.shares_memory(l_iter.X, l_iter_petsc.X)  # sanity check
         np.testing.assert_allclose(l_iter.X, l_iter_petsc.X, rtol=0, atol=tol)
 
-    def test_compute_absorption_probabilities_solver_mean_time(
-        self, adata_large: AnnData
-    ):
+    def test_compute_absorption_probabilities_mean_time(self, adata_large: AnnData):
         vk = VelocityKernel(adata_large).compute_transition_matrix()
         ck = ConnectivityKernel(adata_large).compute_transition_matrix()
         final_kernel = 0.8 * vk + 0.2 * ck
@@ -199,7 +197,7 @@ class TestCFLARE:
 
         # compute lin probs using direct solver
         mc.compute_absorption_probabilities(
-            solver="gmres", use_petsc=False, tol=tol, absorption_pseudotime="first"
+            solver="gmres", use_petsc=False, tol=tol, absorption_pseudotime="mean"
         )
         pt = mc._get(P.ABS_PT)
 
@@ -209,9 +207,7 @@ class TestCFLARE:
         assert (pt.min(), pt.max()) == (0, 1)
         assert mc._get(P.ABS_PT_VAR) is None
 
-    def test_compute_absorption_probabilities_solver_mean_var(
-        self, adata_large: AnnData
-    ):
+    def test_compute_absorption_probabilities_mean_var(self, adata_large: AnnData):
         vk = VelocityKernel(adata_large).compute_transition_matrix()
         ck = ConnectivityKernel(adata_large).compute_transition_matrix()
         final_kernel = 0.8 * vk + 0.2 * ck
@@ -223,7 +219,7 @@ class TestCFLARE:
 
         # compute lin probs using direct solver
         mc.compute_absorption_probabilities(
-            solver="gmres", use_petsc=False, tol=tol, absorption_pseudotime="second"
+            solver="gmres", use_petsc=False, tol=tol, absorption_pseudotime="var"
         )
         pt = mc._get(P.ABS_PT)
         ptv = mc._get(P.ABS_PT_VAR)
@@ -237,6 +233,85 @@ class TestCFLARE:
         assert isinstance(ptv, pd.Series)
         assert mc._absorption_time_var.shape == ptv.shape
         assert ptv.shape == pt.shape
+
+    def test_compute_absorption_probabilities_lineage_absorption_mean(
+        self, adata_large: AnnData
+    ):
+        vk = VelocityKernel(adata_large).compute_transition_matrix()
+        ck = ConnectivityKernel(adata_large).compute_transition_matrix()
+        final_kernel = 0.8 * vk + 0.2 * ck
+        tol = 1e-6
+
+        mc = cr.tl.estimators.CFLARE(final_kernel)
+        mc.compute_eigendecomposition(k=5)
+        mc.compute_final_states(use=2)
+
+        # compute lin probs using direct solver
+        mc.compute_absorption_probabilities(
+            solver="gmres", use_petsc=False, tol=tol, time_to_absorption="0",
+        )
+        at = mc._get(P.LIN_ABS_TIMES)
+
+        assert isinstance(at, pd.DataFrame)
+        np.testing.assert_array_equal(at.index, adata_large.obs_names)
+        np.testing.assert_array_equal(at.columns, ["0 mean"])
+
+    def test_compute_absorption_probabilities_lineage_absorption_var(
+        self, adata_large: AnnData
+    ):
+        vk = VelocityKernel(adata_large).compute_transition_matrix()
+        ck = ConnectivityKernel(adata_large).compute_transition_matrix()
+        final_kernel = 0.8 * vk + 0.2 * ck
+        tol = 1e-6
+
+        mc = cr.tl.estimators.CFLARE(final_kernel)
+        mc.compute_eigendecomposition(k=5)
+        mc.compute_final_states(use=2)
+
+        # compute lin probs using direct solver
+        mc.compute_absorption_probabilities(
+            solver="gmres", use_petsc=False, tol=tol, time_to_absorption={"0": "var"}
+        )
+        at = mc._get(P.LIN_ABS_TIMES)
+
+        assert isinstance(at, pd.DataFrame)
+        np.testing.assert_array_equal(at.index, adata_large.obs_names)
+        np.testing.assert_array_equal(at.columns, ["0 mean", "0 var"])
+
+    def test_compute_absorption_probabilities_absorption_matches_all(
+        self, adata_large: AnnData
+    ):
+        vk = VelocityKernel(adata_large).compute_transition_matrix()
+        ck = ConnectivityKernel(adata_large).compute_transition_matrix()
+        final_kernel = 0.8 * vk + 0.2 * ck
+        tol = 1e-6
+
+        mc = cr.tl.estimators.CFLARE(final_kernel)
+        mc.compute_eigendecomposition(k=5)
+        mc.compute_final_states(use=2)
+
+        fs = tuple(mc._get(P.FIN).cat.categories)
+        names = ", ".join(fs)
+
+        # compute lin probs using direct solver
+        mc.compute_absorption_probabilities(
+            solver="gmres",
+            use_petsc=False,
+            tol=tol,
+            time_to_absorption={fs: "var"},
+            absorption_pseudotime="var",
+        )
+        at_1 = mc._get(P.LIN_ABS_TIMES)
+        at_2_mean = mc._absorption_time_mean
+        at_2_var = mc._absorption_time_var
+
+        assert isinstance(at_1, pd.DataFrame)
+        assert isinstance(at_2_mean, np.ndarray)
+        assert isinstance(at_2_var, np.ndarray)
+        np.testing.assert_array_equal(at_1.index, adata_large.obs_names)
+        np.testing.assert_array_equal(at_1.columns, [f"{names} mean", f"{names} var"])
+        np.testing.assert_allclose(at_1[f"{names} mean"].values, at_2_mean)
+        np.testing.assert_allclose(at_1[f"{names} var"].values, at_2_var)
 
     def test_compute_lineage_drivers_no_lineages(self, adata_large: AnnData):
         vk = VelocityKernel(adata_large).compute_transition_matrix()


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
<!--- Provide a general summary of your changes in the Title above -->
Add time to absorption only to specified lineages.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Clearly and concisely describe your changes. -->
I've added key `time_to_absorption='Alpha'` or `time_to_absorption=['Alpha', 'Beta:var']` to calculate mean time til absorption + variance to the specific lineage. Also rename

## How has this been tested?
<!--- Describe in detail how you've tested your changes. -->
It hasn't.

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
#339 

## Future improvement 
Only singleton absorbing states are supported, but we can combine them, such as `'Alpha, Beta'`.

@Marius1311 would be great if you could give it a go on the lung data.