### PR TITLE
Fix propagation

### DIFF
--- a/cellrank/tl/kernels/_base_kernel.py
+++ b/cellrank/tl/kernels/_base_kernel.py
@@ -2,7 +2,7 @@
 """Kernel module."""
 
 from abc import ABC, abstractmethod
-from copy import copy
+from copy import copy, deepcopy
 from typing import (
     Any,
     Dict,
@@ -31,6 +31,8 @@ from cellrank.tl._utils import (
 )
 from cellrank.ul._utils import _write_graph_data
 from cellrank.tl._constants import Direction, _transition
+from cellrank.ul._parallelize import parallelize
+from cellrank.tl.kernels._utils import _filter_kwargs
 
 _ERROR_DIRECTION_MSG = "Can only combine kernels that have the same direction."
 _ERROR_EMPTY_CACHE_MSG = (
@@ -60,6 +62,8 @@ class KernelExpression(ABC):
     ):
         self._op_name = op_name
         self._transition_matrix = None
+        self._tmats = None
+        self._current_ix = 0
         self._direction = Direction.BACKWARD if backward else Direction.FORWARD
         self._compute_cond_num = compute_cond_num
         self._cond_num = None
@@ -77,13 +81,18 @@ class KernelExpression(ABC):
         """
         Return row-normalized transition matrix.
 
-        If not present, compute it, if all the underlying kernels have been initialized.
+        If not present, it is computed, if all the underlying kernels have been initialized.
         """
 
         if self._parent is None and self._transition_matrix is None:
             self.compute_transition_matrix()
 
         return self._transition_matrix
+
+    @property
+    def transition_matrices(self) -> Optional[List[Union[np.ndarray, spmatrix]]]:
+        """Return sampled transition matrices, if available."""
+        return self._tmats
 
     @property
     def backward(self) -> bool:
@@ -133,14 +142,37 @@ class KernelExpression(ABC):
             Nothing, just updates the :paramref:`transition_matrix` and optionally normalizes it.
         """
 
-        should_norm = ~np.isclose(value.sum(1), 1.0, rtol=TOL).all()
+        self._transition_matrix = _maybe_normalize(
+            value, has_parent=self._parent is not None, normalize=self._normalize
+        )
 
-        if self._parent is None:
-            self._transition_matrix = _normalize(value) if should_norm else value
-        else:
-            self._transition_matrix = (
-                _normalize(value) if self._normalize and should_norm else value
-            )
+    def switch_transition_matrix(self, index: int) -> None:
+        """
+        Switch between transition matrices stored in :paramref:`transition_matrices`.
+
+        Parameters
+        ----------
+        index
+            Index of the transition matrix.
+
+        Returns
+        -------
+        None
+            Nothing, just switches the transition matrix.
+        """
+        if self._tmats is None:
+            raise ValueError("No additional transition matrices found.")
+        if index == self._current_ix and self._transition_matrix is not None:
+            # the None check is because SimpleNaryKernelExpression uses this to set the matrix
+            return
+
+        try:
+            self.transition_matrix = self._tmats[index]
+            self._current_ix = index
+        except IndexError:
+            raise IndexError(
+                f"Invalid index `{index}`. Valid range is `[0, {len(self._tmats)})`."
+            ) from None
 
     @abstractmethod
     def compute_transition_matrix(self, *args, **kwargs) -> "KernelExpression":
@@ -210,6 +242,17 @@ class KernelExpression(ABC):
                 )
             else:
                 logg.info(f"Condition number is `{self._cond_num:.2e}`")
+
+    def _copy_transition_matrix(self, new_obj: "KernelExpression") -> None:
+        if self.transition_matrices is not None:
+            assert (
+                self._transition_matrix is self.transition_matrices[self._current_ix]
+            ), f"Active transition matrix differs from the one with index `{self._current_ix}`."
+            new_obj._tmats = deepcopy(self.transition_matrices)
+            new_obj.switch_transition_matrix(self._current_ix)
+        else:
+            new_obj._transition_matrix = copy(self.transition_matrix)
+            new_obj._current_ix = self._current_ix
 
     @abstractmethod
     def _get_kernels(self) -> Iterable["Kernel"]:
@@ -447,6 +490,28 @@ class NaryKernelExpression(KernelExpression, ABC):
         backward = kexprs[0].backward
         assert all(k.backward == backward for k in kexprs), _ERROR_DIRECTION_MSG
 
+        kexprs_with_tmats = [
+            kexpr for kexpr in kexprs if kexpr.transition_matrices is not None
+        ]
+        if len(kexprs_with_tmats):
+            n_expected = len(kexprs_with_tmats[0].transition_matrices)
+            ix, msg_shown = kexprs_with_tmats[0]._current_ix, False
+
+            for kexpr in kexprs_with_tmats:
+                if len(kexpr.transition_matrices) != n_expected:
+                    raise ValueError(
+                        f"Expected kernel expression `{kexpr}` to have `{n_expected}` transition matrices, "
+                        f"found `{len(kexpr.transition_matrices)}`."
+                    )
+                if kexpr._current_ix != ix and not msg_shown:
+                    logg.warning(
+                        "Expressions have different transition matrix indices. "
+                        "New index will be set to `0`"
+                    )
+                    msg_shown = True
+
+                self._current_ix = 0 if msg_shown else ix
+
         # use OR instead of AND
         super().__init__(
             op_name,
@@ -680,8 +745,9 @@ class Constant(Kernel):
         """Return self."""
         return self
 
-    def copy(self) -> "Constant":
-        """Return a copy of self."""
+    @d.dedent
+    def copy(self) -> "Constant":  # noqa
+        """%(copy)s"""
         return Constant(self.adata, self.transition_matrix, self.backward)
 
     def __invert__(self) -> "Constant":
@@ -725,8 +791,9 @@ class ConstantMatrix(Kernel):
         )
         self._recalculate(value)
 
-    def copy(self) -> "ConstantMatrix":
-        """Return a copy of self."""
+    @d.dedent
+    def copy(self) -> "ConstantMatrix":  # noqa
+        """%(copy)s"""
         return ConstantMatrix(
             self.adata, self._value, copy(self._mat_scaler), self.backward
         )
@@ -778,9 +845,35 @@ class SimpleNaryExpression(NaryKernelExpression):
             elif isinstance(kexpr, Kernel):
                 logg.debug(_LOG_USING_CACHE)
 
-        self.transition_matrix = csr_matrix(
-            self._fn([kexpr.transition_matrix for kexpr in self])
-        )
+        kexprs_with_tmats = [
+            kexpr for kexpr in self if kexpr.transition_matrices is not None
+        ]
+        if len(kexprs_with_tmats):
+            # error checking -the same number of samples - is done in `NaryKernelExpression`
+            n_expected = len(kexprs_with_tmats[0].transition_matrices)
+            logg.debug(f"Combining `{n_expected}` transition matrices")
+            tmats = self._fn(
+                [
+                    (kexpr.transition_matrix,) * n_expected
+                    if kexpr.transition_matrices is None
+                    else kexpr.transition_matrices
+                    for kexpr in self
+                ]
+            )
+            self._tmats = parallelize(
+                _maybe_normalize_multiple,
+                tmats,
+                n_jobs=-1,  # using all cores
+                as_array=False,
+                backend="threading",
+                show_progress_bar=False,
+                extractor=lambda res: tuple(r for rs in res for r in rs),
+            )(has_parent=self._parent is not None, normalize=self._normalize)
+            self.switch_transition_matrix(self._current_ix)
+        else:
+            self.transition_matrix = csr_matrix(
+                self._fn([kexpr.transition_matrix for kexpr in self])
+            )
 
         # only the top level expression and kernels will have condition number computed
         if self._parent is None:
@@ -788,12 +881,13 @@ class SimpleNaryExpression(NaryKernelExpression):
 
         return self
 
-    def copy(self) -> "SimpleNaryExpression":
-        """Return a copy of self."""
+    @d.dedent
+    def copy(self) -> "SimpleNaryExpression":  # noqa
+        """%(copy)s"""
         sne = SimpleNaryExpression(
             [copy(k) for k in self], op_name=self._op_name, fn=self._fn
         )
-        sne._transition_matrix = copy(self._transition_matrix)
+        self._copy_transition_matrix(sne)
 
         return sne
 
@@ -928,7 +1022,29 @@ def _is_bin_mult(
 
 
 def _is_adaptive_type(k: KernelExpression) -> bool:
-    return isinstance(k, Kernel) and not isinstance(k, ((Constant, ConstantMatrix)))
+    return isinstance(k, Kernel) and not isinstance(k, (Constant, ConstantMatrix))
+
+
+def _maybe_normalize(
+    value: Union[np.ndarray, spmatrix],
+    has_parent: bool,
+    normalize: bool,
+) -> Union[np.ndarray, spmatrix]:
+    should_norm = ~np.isclose(value.sum(1), 1.0, rtol=TOL).all()
+
+    if not has_parent:
+        return _normalize(value) if should_norm else value
+
+    return _normalize(value) if normalize and should_norm else value
+
+
+def _maybe_normalize_multiple(
+    matrices: np.ndarray, **kwargs
+) -> List[Union[np.ndarray, spmatrix]]:
+    return [
+        _maybe_normalize(mat, **_filter_kwargs(_maybe_normalize, **kwargs))
+        for mat in matrices
+    ]
 
 
 TOL = 1e-12

--- a/cellrank/tl/kernels/_base_kernel.py
+++ b/cellrank/tl/kernels/_base_kernel.py
@@ -251,7 +251,8 @@ class KernelExpression(ABC):
             new_obj._tmats = deepcopy(self.transition_matrices)
             new_obj.switch_transition_matrix(self._current_ix)
         else:
-            new_obj._transition_matrix = copy(self.transition_matrix)
+            # careful not to call .transition_matrix, as it can compute it
+            new_obj._transition_matrix = copy(self._transition_matrix)
             new_obj._current_ix = self._current_ix
 
     @abstractmethod

--- a/cellrank/tl/kernels/_base_kernel.py
+++ b/cellrank/tl/kernels/_base_kernel.py
@@ -510,7 +510,10 @@ class NaryKernelExpression(KernelExpression, ABC):
                     )
                     msg_shown = True
 
-                self._current_ix = 0 if msg_shown else ix
+                if msg_shown:
+                    ix = 0
+        else:
+            n_expected, ix = 0, 0
 
         # use OR instead of AND
         super().__init__(
@@ -524,6 +527,11 @@ class NaryKernelExpression(KernelExpression, ABC):
 
         for kexprs in self._kexprs:
             kexprs._parent = self
+
+        # must be called after super()
+        if n_expected:
+            self._tmats = (None,) * n_expected
+        self._current_ix = ix
 
     def _maybe_recalculate_constants(self, type_: Type):
         if type_ == Constant:

--- a/cellrank/tl/kernels/_connectivity_kernel.py
+++ b/cellrank/tl/kernels/_connectivity_kernel.py
@@ -95,6 +95,6 @@ class ConnectivityKernel(Kernel):
         ck = ConnectivityKernel(self.adata, backward=self.backward)
         ck._params = copy(self.params)
         ck._cond_num = self.condition_number
-        ck._transition_matrix = copy(self._transition_matrix)
+        self._copy_transition_matrix(ck)
 
         return ck

--- a/cellrank/tl/kernels/_palantir_kernel.py
+++ b/cellrank/tl/kernels/_palantir_kernel.py
@@ -162,6 +162,6 @@ class PalantirKernel(Kernel):
         pk._pseudotime = copy(self.pseudotime)
         pk._params = copy(self._params)
         pk._cond_num = self.condition_number
-        pk._transition_matrix = copy(self._transition_matrix)
+        self._copy_transition_matrix(pk)
 
         return pk

--- a/cellrank/tl/kernels/_precomputed_kernel.py
+++ b/cellrank/tl/kernels/_precomputed_kernel.py
@@ -66,7 +66,7 @@ class PrecomputedKernel(Kernel):
             raise ValueError("Not a valid transition matrix: not all rows sum to 1.")
 
         if adata is None:
-            logg.debug("Creating empty dummy AnnData object")
+            logg.warning("Creating empty `AnnData` object")
             adata = _AnnData(
                 csr_matrix((transition_matrix.shape[0], 1), dtype=np.float32)
             )

--- a/cellrank/tl/kernels/_velocity_kernel.py
+++ b/cellrank/tl/kernels/_velocity_kernel.py
@@ -57,7 +57,7 @@ class VelocityKernel(Kernel):
 
     This borrows ideas from both [Manno18]_ and [Bergen19]_. In short, for each cell *i*, we compute transition
     probabilities :math:`p_{i, j}` to each cell *j* in the neighborhood of *i*. The transition probabilities are
-    computed as a multinominal logistic regression where the weights :math:`w_j` (for all *j*) are given by the vector
+    computed as a multinomial logistic regression where the weights :math:`w_j` (for all *j*) are given by the vector
     that connects cell *i* with cell *j* in gene expression space, and the features :math:`x_i` are given
     by the velocity vector :math:`v_i` of cell *i*.
 
@@ -103,8 +103,6 @@ class VelocityKernel(Kernel):
         self._gene_subset = gene_subset
         self._pearson_correlations = None
 
-        self._current_ix = None
-        self._tmats = None
         self._pcors = None
 
     def _read_from_adata(self, **kwargs):
@@ -309,7 +307,6 @@ class VelocityKernel(Kernel):
         )
         if isinstance(tmat, (tuple, list)):
             self._tmats, self._pcors = tuple(tmat), tuple(cmat)
-            self._current_ix = 0
             tmat, cmat = tmat[self._current_ix], cmat[self._current_ix]
 
         self._compute_transition_matrix(tmat, density_normalize=False)
@@ -318,37 +315,6 @@ class VelocityKernel(Kernel):
         logg.info("    Finish", time=start)
 
         return self
-
-    @inject_docs(m=VelocityMode)
-    def switch_transition_matrix(self, index: int) -> None:
-        """
-        Switch between transition matrices when using ``mode={m.PROPAGATION.s!r}``.
-
-        Parameters
-        ----------
-        index
-            Index of the transition matrix. The matrices are stored in :paramref:`_tmats`.
-
-        Returns
-        -------
-        None
-            Nothing, just switches the transition matrix.
-        """
-        if self._tmats is None:
-            raise ValueError(
-                f"No additional transition matrices found. Compute them first as "
-                f"`.compute_transition_matrix(mode={VelocityMode.PROPAGATION.s!r}, ...)`."
-            )
-        if index == self._current_ix:
-            return
-
-        try:
-            self._transition_matrix = self._tmats[index]
-            self._current_ix = index
-        except IndexError:
-            raise IndexError(
-                f"Invalid index `{index}`. Valid range is `[0, {len(self._tmats)})`."
-            ) from None
 
     @property
     def pearson_correlations(self) -> csr_matrix:  # noqa
@@ -367,11 +333,9 @@ class VelocityKernel(Kernel):
         )
         vk._params = copy(self.params)
         vk._cond_num = self.condition_number
-        vk._transition_matrix = copy(self._transition_matrix)
+        self._copy_transition_matrix(vk)
         vk._pearson_correlations = copy(self.pearson_correlations)
-        vk._tmats = deepcopy(self._tmats)
         vk._pcors = deepcopy(self._pcors)
-        vk._current_ix = self._current_ix
 
         return vk
 

--- a/cellrank/tl/kernels/_velocity_kernel.py
+++ b/cellrank/tl/kernels/_velocity_kernel.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Velocity kernel module."""
+from sys import version_info
 from copy import copy, deepcopy
 from math import fsum
 from typing import Any, Union, Callable, Iterable, Optional
@@ -257,7 +258,10 @@ class VelocityKernel(Kernel):
             mode = VelocityMode.SAMPLING
 
         backend = kwargs.pop("backend", _DEFAULT_BACKEND)
-        if mode != VelocityMode.STOCHASTIC and backend == "multiprocessing":
+        if version_info[:2] <= (3, 6):
+            logg.warning("For Python3.6, only `'threading'` backend is supported")
+            backend = "threading"
+        elif mode != VelocityMode.STOCHASTIC and backend == "multiprocessing":
             # this is because on jitting and pickling (cloudpickle, used by loky, handles it correctly)
             logg.warning(
                 f"Multiprocessing backend is supported only for mode `{VelocityMode.STOCHASTIC.s!r}`. "

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1154,7 +1154,10 @@ class TestVelocityKernel:
             mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
         )
         vk2 = VelocityKernel(adata).compute_transition_matrix(
-            mode="deterministic", show_progress_bar=False, n_jobs=4
+            mode="deterministic",
+            show_progress_bar=False,
+            n_jobs=4,
+            backend="loky",
         )
         ck1 = ConnectivityKernel(adata).compute_transition_matrix()
         ck2 = ConnectivityKernel(adata).compute_transition_matrix()

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -991,14 +991,14 @@ class TestMonteCarlo:
 
 
 class TestVelocityKernel:
-    def test_matrix_switch_no_prop(self, adata: AnnData):
+    def test_switch_no_prop(self, adata: AnnData):
         vk = VelocityKernel(adata)
         vk.compute_transition_matrix(mode="deterministic", show_progress_bar=False)
 
         with pytest.raises(ValueError):
             vk.switch_transition_matrix(1)
 
-    def test_matrix_switch_invalid_index(self, adata: AnnData):
+    def test_switch_invalid_index(self, adata: AnnData):
         vk = VelocityKernel(adata)
         vk.compute_transition_matrix(
             mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
@@ -1007,7 +1007,7 @@ class TestVelocityKernel:
         with pytest.raises(IndexError):
             vk.switch_transition_matrix(42)
 
-    def test_matrix_switch_normal_run(self, adata: AnnData):
+    def test__switch_normal_run(self, adata: AnnData):
         vk = VelocityKernel(adata)
         vk.compute_transition_matrix(
             mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
@@ -1031,3 +1031,87 @@ class TestVelocityKernel:
         )
 
         assert vk.params["softmax_scale"] is not None
+
+    def test_propagation_with_connectivity(self, adata: AnnData):
+        k = (
+            VelocityKernel(adata).compute_transition_matrix(
+                mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
+            )
+            + ConnectivityKernel(adata).compute_transition_matrix()
+        )
+        k.compute_transition_matrix()
+
+        assert isinstance(k.transition_matrices, tuple)
+        assert len(k.transition_matrices) == 10
+        assert k.transition_matrix is k.transition_matrices[k._current_ix]
+
+    def test_propagation_with_connectivity_copy(self, adata: AnnData):
+        k = (
+            VelocityKernel(adata).compute_transition_matrix(
+                mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
+            )
+            + ConnectivityKernel(adata).compute_transition_matrix()
+        )
+        k.compute_transition_matrix()
+
+        k2 = k.copy()
+
+        assert isinstance(k2.transition_matrices, tuple)
+        assert len(k2.transition_matrices) == 10
+        assert k2.transition_matrix is k2.transition_matrices[k._current_ix]
+
+        for i, tmat in enumerate(k2.transition_matrices):
+            assert tmat is not k.transition_matrices[i]
+
+    def test_propagation_different_n_samples(self, adata: AnnData):
+        vk1 = VelocityKernel(adata).compute_transition_matrix(
+            mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
+        )
+        vk2 = VelocityKernel(adata).compute_transition_matrix(
+            mode="propagation", show_progress_bar=False, n_samples=11, n_jobs=4
+        )
+
+        with pytest.raises(ValueError):
+            _ = vk1 + vk2
+
+    def test_propagation_same_index(self, adata: AnnData):
+        vk1 = VelocityKernel(adata).compute_transition_matrix(
+            mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
+        )
+        vk1.switch_transition_matrix(5)
+
+        vk2 = VelocityKernel(adata).compute_transition_matrix(
+            mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
+        )
+        vk2.switch_transition_matrix(5)
+
+        assert vk1._current_ix == 5
+        assert vk2._current_ix == 5
+
+        k = (vk1 + vk2).compute_transition_matrix()
+
+        assert k._current_ix == 5
+        assert k.transition_matrix is k.transition_matrices[5]
+        assert isinstance(k.transition_matrices, tuple)
+        assert len(k.transition_matrices) == 10
+
+    def test_propagation_different_index(self, adata: AnnData):
+        vk1 = VelocityKernel(adata).compute_transition_matrix(
+            mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
+        )
+        vk1.switch_transition_matrix(4)
+
+        vk2 = VelocityKernel(adata).compute_transition_matrix(
+            mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
+        )
+        vk2.switch_transition_matrix(2)
+
+        assert vk1._current_ix == 4
+        assert vk2._current_ix == 2
+
+        k = (vk1 + vk2).compute_transition_matrix()
+
+        assert k._current_ix == 0
+        assert k.transition_matrix is k.transition_matrices[0]
+        assert isinstance(k.transition_matrices, tuple)
+        assert len(k.transition_matrices) == 10

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1115,3 +1115,36 @@ class TestVelocityKernel:
         assert k.transition_matrix is k.transition_matrices[0]
         assert isinstance(k.transition_matrices, tuple)
         assert len(k.transition_matrices) == 10
+
+    def test_propagation_addition(self, adata: AnnData):
+        vk1 = VelocityKernel(adata).compute_transition_matrix(
+            mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
+        )
+        vk2 = VelocityKernel(adata).compute_transition_matrix(
+            mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
+        )
+        k = (vk1 + vk2).compute_transition_matrix()
+
+        for i in range(len(k.transition_matrices)):
+            np.testing.assert_array_equal(
+                k.transition_matrices[i].A,
+                (0.5 * vk1.transition_matrices[i] + 0.5 * vk2.transition_matrices[i]).A,
+            )
+
+    def test_propagation_multiplication(self, adata: AnnData):
+        vk1 = VelocityKernel(adata).compute_transition_matrix(
+            mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
+        )
+        vk2 = VelocityKernel(adata).compute_transition_matrix(
+            mode="propagation", show_progress_bar=False, n_samples=10, n_jobs=4
+        )
+        k = ((6 * vk1) * (9 * vk2)).compute_transition_matrix()
+
+        for i in range(len(k.transition_matrices)):
+            np.testing.assert_allclose(
+                k.transition_matrices[i].A,
+                _normalize(
+                    ((6 / 9) * vk1.transition_matrices[i])
+                    * ((9 / 6) * vk2.transition_matrices[i])
+                ).A,
+            )


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
<!--- Provide a general summary of your changes in the Title above -->
Propagation transition matrices to complex kernel expressions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Clearly and concisely describe your changes. -->
`switch_trasition_matrix` is now available to all kernels and expression, the matrices can be accessed as `.transition_matrices`.
This was done because I expect in the future, we will introduce some stochasticity in other methods.

## How has this been tested?
<!--- Describe in detail how you've tested your changes. -->
Yes, many times.

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #355 
