### PR TITLE
Use scanpy's vega_20 colors first

### DIFF
--- a/cellrank/tl/_colors.py
+++ b/cellrank/tl/_colors.py
@@ -90,7 +90,16 @@ def _convert_to_hex_colors(colors: Sequence[Any]) -> List[str]:
 
 
 def _create_categorical_colors(n_categories: Optional[int] = None):
-    cmaps = [cm.tab10, cm.tab20, cm.Paired, cm.Accent, cm.Set1, cm.Set2, cm.Set3]
+    from scanpy.plotting.palettes import vega_20_scanpy
+
+    cmaps = [
+        mcolors.ListedColormap(vega_20_scanpy),
+        cm.Accent,
+        mcolors.ListedColormap(np.array(cm.Dark2.colors)[[1, 2, 4, 5, 6]]),
+        cm.Set1,
+        cm.Set2,
+        cm.Set3,
+    ]
     max_cats = sum(c.N for c in cmaps)
 
     if n_categories is None:

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -25,9 +25,9 @@ class TestColors:
             _create_categorical_colors(-1)
 
     def test_create_categorical_colors_normal_run(self):
-        colors = _create_categorical_colors(79)
+        colors = _create_categorical_colors(62)
 
-        assert len(colors) == 79
+        assert len(colors) == 62
         assert all(map(lambda c: isinstance(c, str), colors))
         assert all(map(lambda c: is_color_like(c), colors))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,7 +97,7 @@ class TestToolsUtils:
             x, y, colors_old=colors_x, inplace=True
         )
 
-        np.testing.assert_array_equal(colors_merged, ["red", "blue", "#2ca02c"])
+        np.testing.assert_array_equal(colors_merged, ["red", "blue", "#279e68"])
 
     def test_merge_colors_simple_old_no_inplace(self):
         x = pd.Series(["a", "b", np.nan, "b", np.nan]).astype("category")
@@ -110,7 +110,7 @@ class TestToolsUtils:
         )
 
         np.testing.assert_array_equal(merged.values, expected.values)
-        np.testing.assert_array_equal(colors_merged, ["red", "blue", "#2ca02c"])
+        np.testing.assert_array_equal(colors_merged, ["red", "blue", "#279e68"])
 
     def test_merge_colors_simple_new(self):
         x = pd.Series(["a", "b", np.nan, "b", np.nan]).astype("category")


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Clearly and concisely describe your changes. -->
Updated the categorical colormap (use scanpy's vega_20 as first 20 colors).
![cmap](https://user-images.githubusercontent.com/46717574/95193888-d43a8c00-07d4-11eb-88c0-cd64653e548c.png)


## How has this been tested?
<!--- Describe in detail how you've tested your changes. -->

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #419 
