### PR TITLE
Enable showing no legend

### DIFF
--- a/cellrank/pl/_graph.py
+++ b/cellrank/pl/_graph.py
@@ -505,7 +505,7 @@ def graph(
                 seen.add(v)
 
             nodes_kwargs = dict(cmap=cat_cmap, node_color=colors)  # noqa
-            if legend_loc is not None:
+            if legend_loc not in ("none", None):
                 x, y = pos[0]
                 for label in sorted(seen):
                     ax.plot([x], [y], label=label, color=mapper[label])

--- a/cellrank/pl/_utils.py
+++ b/cellrank/pl/_utils.py
@@ -790,7 +790,7 @@ def _trends_helper(
             ticks=np.linspace(norm.vmin, norm.vmax, 5),
         )
 
-    if same_plot and lineage_names != [None] and legend_loc is not None:
+    if same_plot and lineage_names != [None] and legend_loc not in (None, "none"):
         handles = [
             mpl.lines.Line2D([], [], color=lineage_color_mapper[ln], label=ln)
             for ln in successful_models.keys()
@@ -818,9 +818,7 @@ def _position_legend(ax: mpl.axes.Axes, legend_loc: str, **kwargs) -> mpl.legend
     """
 
     if legend_loc == "center center out":
-        raise ValueError(
-            "Invalid option: `'center center out'`. Doesn't really make sense, does it?"
-        )
+        raise ValueError("Invalid option: `'center center out'`.")
     if legend_loc == "best":
         return ax.legend(loc="best", **kwargs)
 

--- a/cellrank/tl/_lineage.py
+++ b/cellrank/tl/_lineage.py
@@ -785,7 +785,7 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
                 if not autopct_found:
                     at.set_text(f"{reduction[ix]:.4f}")
 
-        if legend_loc not in (None, "on data"):
+        if legend_loc not in (None, "none", "on data"):
             ax.legend(
                 wedges,
                 self.names,

--- a/cellrank/tl/estimators/_decomposition.py
+++ b/cellrank/tl/estimators/_decomposition.py
@@ -360,7 +360,7 @@ class Eigen(VectorPlottable, Decomposable):
 
         # add dashed line for the eigengap, ticks, labels, title and legend
         if show_eigengap and eig["eigengap"] < n:
-            ax.axvline(eig["eigengap"], label="eigengap", ls="--", lw=1)
+            ax.axvline(eig["eigengap"], label="eigengap", ls="--", lw=2, c="k")
 
         ax.set_xlabel("index")
         if show_all_xticks:

--- a/cellrank/tl/estimators/_decomposition.py
+++ b/cellrank/tl/estimators/_decomposition.py
@@ -376,7 +376,8 @@ class Eigen(VectorPlottable, Decomposable):
             title = f"real part of top {n} eigenvalues according to their {key}"
 
         ax.set_title(title)
-        ax.legend(loc=legend_loc)
+        if legend_loc != "none":
+            ax.legend(loc=legend_loc)
 
         return fig
 

--- a/cellrank/tl/estimators/_decomposition.py
+++ b/cellrank/tl/estimators/_decomposition.py
@@ -316,7 +316,8 @@ class Eigen(VectorPlottable, Decomposable):
             title = f"top {n} eigenvalues according to their {key}"
 
         ax.set_title(title)
-        ax.legend(loc=legend_loc)
+        if legend_loc not in (None, "none"):
+            ax.legend(loc=legend_loc)
 
         return fig
 
@@ -376,7 +377,7 @@ class Eigen(VectorPlottable, Decomposable):
             title = f"real part of top {n} eigenvalues according to their {key}"
 
         ax.set_title(title)
-        if legend_loc != "none":
+        if legend_loc not in (None, "none"):
             ax.legend(loc=legend_loc)
 
         return fig

--- a/cellrank/ul/models/_base_model.py
+++ b/cellrank/ul/models/_base_model.py
@@ -911,7 +911,7 @@ class BaseModel(Pickleable, ABC, metaclass=BaseModelMeta):
                 label="probability",
             )
 
-            if kwargs.get("loc", "best") is not None:
+            if kwargs.get("loc", "best") not in (None, "none"):
                 ax.legend(handles=handle, **kwargs)
 
         if (


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
Really simple fix when I want to show no legend when plotting

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)

## Description
This enables showing no legend in the `_plot_real_spectrum` method when passing `legend="none"`

## How has this been tested?
Not at all. 

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
