### PR TITLE
Fix lineage drivers, bump/restrict some reqs

### DIFF
--- a/cellrank/tl/_utils.py
+++ b/cellrank/tl/_utils.py
@@ -459,12 +459,11 @@ def _correlation_test(
     )
 
     res = pd.DataFrame(corr, index=gene_names, columns=[f"{c} corr" for c in Y.names])
-    res[[f"{c} pval" for c in Y.names]] = pvals
-    res[[f"{c} qval" for c in Y.names]] = res[[f"{c} pval" for c in Y.names]].apply(
-        lambda c: multipletests(c, alpha=0.05, method="fdr_bh")[1]
-    )
-    res[[f"{c} ci low" for c in Y.names]] = ci_low
-    res[[f"{c} ci high" for c in Y.names]] = ci_high
+    for idx, c in enumerate(Y.names):
+        res[f"{c} pval"] = pvals[:, idx]
+        res[f"{c} qval"] = multipletests(pvals[:, idx], alpha=0.05, method="fdr_bh")[1]
+        res[f"{c} ci low"] = ci_low[:, idx]
+        res[f"{c} ci high"] = ci_high[:, idx]
 
     res = res[
         [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 anndata>=0.7.2
-docrep>=0.2.7
+docrep>=0.2.7,<0.3
 future_fstrings
 h5py>=2.0.0,<3.0.0  # https://github.com/theislab/scanpy/issues/1480
 ipywidgets>=7.5.1
@@ -8,7 +8,7 @@ matplotlib>=3.3.0
 networkx>=2.2
 numba>=0.51.0
 numpy>=1.19.1
-pandas>=0.23.4
+pandas>=1.0.0
 pygam>=0.8.0
 scanpy>=1.6.0
 scikit-learn>=0.21.3


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
<!--- Provide a general summary of your changes in the Title above -->
Pandas indexing error `cr.tl.lin_drivers` for `pandas==1.0.1`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Clearly and concisely describe your changes. -->

## How has this been tested?
<!--- Describe in detail how you've tested your changes. -->
No, for `pandas==1.2.0` that I have locally, it was fine and the proposal in #474 fixes this.
Also bumps pandas min. req to `1.0.0` and max. docrep to `0.3`

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #474 
