### PR TITLE
Add explicit copy to fix #483

### DIFF
--- a/cellrank/tl/kernels/_utils.py
+++ b/cellrank/tl/kernels/_utils.py
@@ -191,8 +191,8 @@ def _reconstruct_one(
 
     # strange bug happens when no copying and eliminating zeros from cors (it's no longer row-stochastic)
     # only happens when using numba
-    probs = csr_matrix((data[0].copy(), mat.indices.copy(), mat.indptr.copy()))
-    cors = csr_matrix((data[1].copy(), mat.indices.copy(), mat.indptr.copy()))
+    probs = csr_matrix((np.array(data[0]), np.array(mat.indices), np.array(mat.indptr)))
+    cors = csr_matrix((np.array(data[1]), np.array(mat.indices), np.array(mat.indptr)))
 
     if aixs is not None:
         assert (

--- a/cellrank/tl/kernels/_utils.py
+++ b/cellrank/tl/kernels/_utils.py
@@ -191,8 +191,8 @@ def _reconstruct_one(
 
     # strange bug happens when no copying and eliminating zeros from cors (it's no longer row-stochastic)
     # only happens when using numba
-    probs = csr_matrix((data[0].copy(), mat.indices, mat.indptr))
-    cors = csr_matrix((data[1].copy(), mat.indices, mat.indptr))
+    probs = csr_matrix((data[0].copy(), mat.indices.copy(), mat.indptr.copy()))
+    cors = csr_matrix((data[1].copy(), mat.indices.copy(), mat.indptr.copy()))
 
     if aixs is not None:
         assert (

--- a/cellrank/tl/kernels/_utils.py
+++ b/cellrank/tl/kernels/_utils.py
@@ -191,8 +191,8 @@ def _reconstruct_one(
 
     # strange bug happens when no copying and eliminating zeros from cors (it's no longer row-stochastic)
     # only happens when using numba
-    probs = csr_matrix((data[0], mat.indices, mat.indptr))
-    cors = csr_matrix((data[1], mat.indices, mat.indptr))
+    probs = csr_matrix((data[0].copy(), mat.indices, mat.indptr))
+    cors = csr_matrix((data[1].copy(), mat.indices, mat.indptr))
 
     if aixs is not None:
         assert (

--- a/cellrank/tl/kernels/_utils.py
+++ b/cellrank/tl/kernels/_utils.py
@@ -203,11 +203,11 @@ def _reconstruct_one(
     probs.eliminate_zeros()
     cors.eliminate_zeros()
 
-    close_to_1 = np.isclose(np.array(probs.sum(1)).squeeze(), 1.0)
+    row_sums = np.array(probs.sum(1).squeeze())
+    close_to_1 = np.isclose(row_sums, 1.0)
     if not np.all(close_to_1):
         raise ValueError(
-            f"Matrix is not row-stochastic. "
-            f"The following rows don't sum to 1: `{list(np.where(~close_to_1)[0])}`."
+            f"Matrix is not row-stochastic. The following rows don't sum to 1: `{row_sums[~close_to_1]}`."
         )
 
     return probs, cors


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
<!--- Provide a general summary of your changes in the Title above -->
@carynwillis
Could you please try the fix I've introduces in this branch? You should be able to install it as
```bash
pip install git+https://github.com/theislab/cellrank@add_explicit_copy
```
To verify it's the correct version, you can run:
```python
import cellrank as cr
print(cr.__full_version__)  # should be '1.2.0+gb5a843b'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Clearly and concisely describe your changes. -->
Explicitly copy the arrays before converting them to CSR matrices.

## How has this been tested?
<!--- Describe in detail how you've tested your changes. -->
No, because I am not sure how to reproduce this.

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #483 