### PR TITLE
Dont force sparse tmat if already dense

### DIFF
--- a/cellrank/tl/_utils.py
+++ b/cellrank/tl/_utils.py
@@ -769,7 +769,7 @@ def _normalize(X: Union[np.ndarray, spmatrix]) -> Union[np.ndarray, spmatrix]:
 
     Returns
     -------
-    :class:`numpy.ndarray` or :class:`scipy.sparse.spmatrx`
+    :class:`numpy.ndarray` or :class:`scipy.sparse.spmatrix`
         The normalized array.
     """
 

--- a/cellrank/tl/kernels/_base_kernel.py
+++ b/cellrank/tl/kernels/_base_kernel.py
@@ -96,7 +96,7 @@ class KernelExpression(Pickleable, ABC):
         """
         Return row-normalized transition matrix.
 
-        If not present, it is computed, if all the underlying kernels have been initialized.
+        If not present, it is computed iff all underlying kernels have been initialized.
         """
 
         if self._parent is None and self._transition_matrix is None:
@@ -166,13 +166,15 @@ class KernelExpression(Pickleable, ABC):
             )
 
     @abstractmethod
-    def compute_transition_matrix(self, *args, **kwargs) -> "KernelExpression":
+    def compute_transition_matrix(
+        self, *args: Any, **kwargs: Any
+    ) -> "KernelExpression":
         """
         Compute a transition matrix.
 
         Parameters
         ----------
-        *args
+        args
             Positional arguments.
         kwargs
             Keyword arguments.
@@ -904,12 +906,13 @@ class Kernel(UnaryKernelExpression, ABC):
 
     def _compute_transition_matrix(
         self,
-        matrix: spmatrix,
+        matrix: Union[np.ndarray, spmatrix],
         density_normalize: bool = True,
         check_irreducibility: bool = False,
     ):
         # density correction based on node degrees in the KNN graph
-        matrix = csr_matrix(matrix) if not isspmatrix_csr(matrix) else matrix
+        if issparse(matrix) and not isspmatrix_csr(matrix):
+            matrix = csr_matrix(matrix)
 
         if density_normalize:
             matrix = self._density_normalize(matrix)

--- a/cellrank/tl/kernels/_base_kernel.py
+++ b/cellrank/tl/kernels/_base_kernel.py
@@ -940,7 +940,7 @@ class Constant(Kernel):
     ----------
     %(adata)s
     value
-        Constant value by which to multiply Must be a positive number.
+        Constant value by which to multiply. Must be a positive number.
     %(backward)s
     """
 

--- a/cellrank/tl/kernels/_base_kernel.py
+++ b/cellrank/tl/kernels/_base_kernel.py
@@ -844,7 +844,7 @@ class Kernel(UnaryKernelExpression, ABC):
         backward: bool = False,
         compute_cond_num: bool = False,
         check_connectivity: bool = False,
-        **kwargs,
+        **kwargs: Any,
     ):
         super().__init__(
             adata, backward, op_name=None, compute_cond_num=compute_cond_num, **kwargs
@@ -893,11 +893,7 @@ class Kernel(UnaryKernelExpression, ABC):
         logg.debug("Density-normalizing the transition matrix")
 
         q = np.asarray(self._conn.sum(axis=0))
-
-        if not issparse(other):
-            Q = np.diag(1.0 / q)
-        else:
-            Q = spdiags(1.0 / q, 0, other.shape[0], other.shape[0])
+        Q = spdiags(1.0 / q, 0, other.shape[0], other.shape[0])
 
         return Q @ other @ Q
 
@@ -910,10 +906,11 @@ class Kernel(UnaryKernelExpression, ABC):
         density_normalize: bool = True,
         check_irreducibility: bool = False,
     ):
-        # density correction based on node degrees in the KNN graph
+        matrix = matrix.astype(_dtype)
         if issparse(matrix) and not isspmatrix_csr(matrix):
             matrix = csr_matrix(matrix)
 
+        # density correction based on node degrees in the KNN graph
         if density_normalize:
             matrix = self._density_normalize(matrix)
 

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,3 +1,4 @@
+from copy import copy
 from typing import Tuple, Callable, Optional
 
 import pytest
@@ -13,6 +14,8 @@ from scanpy import Neighbors
 from anndata import AnnData
 
 import numpy as np
+from scipy.sparse import eye as speye
+from scipy.sparse import isspmatrix_csr
 from pandas.core.dtypes.common import is_bool_dtype, is_integer_dtype
 
 import cellrank as cr
@@ -27,9 +30,11 @@ from cellrank.tl.kernels import (
 )
 from cellrank.tl._constants import _transition
 from cellrank.tl.kernels._base_kernel import (
+    Kernel,
     Constant,
     KernelAdd,
     KernelMul,
+    _dtype,
     _is_bin_mult,
 )
 from cellrank.tl.kernels._cytotrace_kernel import CytoTRACEAggregation, _ct
@@ -55,6 +60,22 @@ class CustomFuncHessian(CustomFunc):
     ) -> np.ndarray:
         # should be either (n, g, g) or (n, g), will be (g, g)
         return np.zeros((D.shape[0], v.shape[0], v.shape[0]))
+
+
+class CustomKernel(Kernel):
+    def compute_transition_matrix(
+        self, sparse: bool = False, dnorm: bool = False
+    ) -> "KernelExpression":
+        if sparse:
+            tmat = speye(self.adata.n_obs, dtype=np.float32)
+        else:
+            tmat = np.eye(self.adata.n_obs, dtype=np.float32)
+
+        self._compute_transition_matrix(tmat, density_normalize=dnorm)
+        return self
+
+    def copy(self) -> "KernelExpression":
+        return copy(self)
 
 
 class InvalidFuncProbs(cr.tl.kernels.SimilaritySchemeABC):
@@ -496,6 +517,18 @@ class TestKernel:
         np.testing.assert_array_almost_equal(
             expected.toarray(), actual.transition_matrix.toarray()
         )
+
+    @pytest.mark.parametrize("dnorm", [False, True])
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_custom_preserves_type(self, adata: AnnData, sparse: bool, dnorm: bool):
+        c = CustomKernel(adata).compute_transition_matrix(sparse=sparse, dnorm=dnorm)
+
+        if sparse:
+            assert isspmatrix_csr(c.transition_matrix)
+        else:
+            assert isinstance(c.transition_matrix, np.ndarray)
+
+        assert c.transition_matrix.dtype == _dtype
 
     def test_write_adata(self, adata: AnnData):
         vk = VelocityKernel(adata).compute_transition_matrix(softmax_scale=4)

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -780,7 +780,7 @@ class TestKernel:
         T_cr = ck.transition_matrix
 
         assert key == ck.params["key"]
-        np.testing.assert_array_equal(T_cr.A, adata.obsp[key])
+        np.testing.assert_array_equal(T_cr, adata.obsp[key])
 
         del adata.obsp[key]
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -279,7 +279,7 @@ class TestTransitionMatrix:
 
         assert isinstance(ck, cr.tl.kernels.ConnectivityKernel)
 
-        np.testing.assert_array_equal(ck.transition_matrix.A, adata.obsp[key])
+        np.testing.assert_array_equal(ck.transition_matrix, adata.obsp[key])
 
     def test_only_velocity(self, adata: AnnData):
         vk = cr.tl.transition_matrix(adata, weight_connectivities=0)


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Clearly and concisely describe your changes. -->
Do not force transiton matrix to be sparse if it's not sparse, do not construct dense array in dens. norm,
force tmat to be always f64.

## How has this been tested?
<!--- Describe in detail how you've tested your changes. -->
Add test to see if sparse/dense is preserved + f64 is retained.

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
related #585