### PR TITLE
Fix custom connectivities key

### DIFF
--- a/cellrank/tl/_transition_matrix.py
+++ b/cellrank/tl/_transition_matrix.py
@@ -46,8 +46,7 @@ def transition_matrix(
     xkey
         Key in ``adata.layers`` where expected gene expression counts are stored.
     conn_key
-        Key in :attr:`anndata.AnnData.obsp` to obtain the connectivity matrix, describing cell-cell similarity. Only
-        used when ``weight_connectivities > 0``.
+        Key in :attr:`anndata.AnnData.obsp` to obtain the connectivity matrix, describing cell-cell similarity.
     gene_subset
         List of genes to be used to compute transition probabilities.
         By default, genes from ``adata.var['velocity_genes']`` are used.
@@ -74,7 +73,12 @@ def transition_matrix(
 
     def compute_velocity_kernel() -> VelocityKernel:
         return VelocityKernel(
-            adata, backward=backward, vkey=vkey, xkey=xkey, gene_subset=gene_subset
+            adata,
+            backward=backward,
+            vkey=vkey,
+            xkey=xkey,
+            gene_subset=gene_subset,
+            conn_key=conn_key,
         ).compute_transition_matrix(
             softmax_scale=softmax_scale,
             mode=mode,

--- a/cellrank/tl/kernels/_base_kernel.py
+++ b/cellrank/tl/kernels/_base_kernel.py
@@ -38,7 +38,6 @@ from cellrank.tl._utils import (
     _normalize,
     _symmetric,
     _get_neighs,
-    _has_neighs,
     _irreducible,
 )
 from cellrank.ul._utils import Pickleable, _write_graph_data
@@ -830,8 +829,7 @@ class Kernel(UnaryKernelExpression, ABC):
     ----------
     %(adata)s
     %(backward)s
-    compute_cond_num
-        Whether to compute the condition number of the transition matrix. For large matrices, this can be very slow.
+    %(cond_num)s
     check_connectivity
         Check whether the underlying KNN graph is connected.
     kwargs
@@ -851,13 +849,14 @@ class Kernel(UnaryKernelExpression, ABC):
         )
         self._read_from_adata(check_connectivity=check_connectivity, **kwargs)
 
-    def _read_from_adata(self, key: str = "connectivities", **kwargs: Any) -> None:
+    def _read_from_adata(
+        self, conn_key: Optional[str] = "connectivities", **kwargs: Any
+    ) -> None:
         """Import the base-KNN graph and optionally check for symmetry and connectivity."""
 
-        if not _has_neighs(self.adata):
-            raise KeyError("Compute KNN graph first as `scanpy.pp.neighbors()`.")
-
-        self._conn = _get_neighs(self.adata, key).astype(_dtype)
+        self._conn = _get_neighs(
+            self.adata, mode="connectivities", key=conn_key
+        ).astype(_dtype)
 
         check_connectivity = kwargs.pop("check_connectivity", False)
         if check_connectivity:

--- a/cellrank/tl/kernels/_connectivity_kernel.py
+++ b/cellrank/tl/kernels/_connectivity_kernel.py
@@ -29,7 +29,7 @@ class ConnectivityKernel(Kernel):
     %(adata)s
     %(backward)s
     conn_key
-        Key in :attr:`anndata.AnnData.obsp` to obtain the connectivity matrix, describing cell-cell similarity.
+        Key in :attr:`anndata.AnnData.obsp` to obtain the connectivity matrix describing cell-cell similarity.
     %(cond_num)s
     check_connectivity
         Check whether the underlying KNN graph is connected.
@@ -48,7 +48,7 @@ class ConnectivityKernel(Kernel):
             backward=backward,
             compute_cond_num=compute_cond_num,
             check_connectivity=check_connectivity,
-            key=conn_key,
+            conn_key=conn_key,
         )
         self._key = conn_key
 

--- a/cellrank/tl/kernels/_cytotrace_kernel.py
+++ b/cellrank/tl/kernels/_cytotrace_kernel.py
@@ -44,9 +44,11 @@ class CytoTRACEKernel(PseudotimeKernel):
     %(backward)s
     %(cytotrace.parameters)s
 
-    compute_cond_num
-        Whether to compute condition number of the transition matrix. Note that this might be costly,
-        since it does not use sparse implementation.
+    %(cond_num)s
+    check_connectivity
+        Check whether the underlying KNN graph is connected.
+    kwargs
+        Keyword arguments for :class:`cellrank.tl.kernels.PseudotimeKernel`.
 
     Examples
     --------
@@ -80,6 +82,7 @@ class CytoTRACEKernel(PseudotimeKernel):
         use_raw: bool = False,
         compute_cond_num: bool = False,
         check_connectivity: bool = False,
+        **kwargs: Any,
     ):
         super().__init__(
             adata,
@@ -90,6 +93,7 @@ class CytoTRACEKernel(PseudotimeKernel):
             layer=layer,
             aggregation=aggregation,
             use_raw=use_raw,
+            **kwargs,
         )
         self._time_key = _ct("pseudotime")  # quirk or PT kernel
 

--- a/cellrank/tl/kernels/_precomputed_kernel.py
+++ b/cellrank/tl/kernels/_precomputed_kernel.py
@@ -30,6 +30,8 @@ class PrecomputedKernel(Kernel):
     %(adata)s
     %(backward)s
     %(cond_num)s
+    kwargs
+        Keyword arguments for :class:`cellrank.tl.kernels.Kernel`.
     """
 
     def __init__(
@@ -40,6 +42,7 @@ class PrecomputedKernel(Kernel):
         adata: Optional[AnnData] = None,
         backward: bool = False,
         compute_cond_num: bool = False,
+        **kwargs: Any,
     ):
         from anndata import AnnData as _AnnData
 
@@ -97,14 +100,16 @@ class PrecomputedKernel(Kernel):
                 csr_matrix((transition_matrix.shape[0], 1), dtype=np.float32)
             )
 
-        super().__init__(adata, backward=backward, compute_cond_num=compute_cond_num)
+        super().__init__(
+            adata, backward=backward, compute_cond_num=compute_cond_num, **kwargs
+        )
 
         self._params = params
         self._transition_matrix = csr_matrix(transition_matrix)
         self._maybe_compute_cond_num()
 
     def _read_from_adata(self, **kwargs: Any) -> None:
-        pass
+        self._conn = None
 
     @d.dedent
     def copy(self) -> "PrecomputedKernel":

--- a/cellrank/tl/kernels/_pseudotime_kernel.py
+++ b/cellrank/tl/kernels/_pseudotime_kernel.py
@@ -37,9 +37,9 @@ class PseudotimeKernel(Kernel):
     %(backward)s
     time_key
         Key in :attr:`adata` ``.obs`` where the pseudotime is stored.
-    compute_cond_num
-        Whether to compute condition number of the transition matrix. Note that this might be costly,
-        since it does not use sparse implementation.
+    %(cond_num)s
+    kwargs
+        Keyword arguments for :class:`cellrank.tl.kernels.Kernel`.
     """
 
     def __init__(

--- a/cellrank/tl/kernels/_velocity_kernel.py
+++ b/cellrank/tl/kernels/_velocity_kernel.py
@@ -66,6 +66,8 @@ class VelocityKernel(Kernel):
     %(cond_num)s
     check_connectivity
         Check whether the underlying KNN graph is connected.
+    kwargs
+        Keyword arguments for :class:`cellrank.tl.kernels.Kernel`.
     """
 
     def __init__(
@@ -77,6 +79,7 @@ class VelocityKernel(Kernel):
         gene_subset: Optional[Iterable] = None,
         compute_cond_num: bool = False,
         check_connectivity: bool = False,
+        **kwargs: Any,
     ):
         super().__init__(
             adata,
@@ -86,6 +89,7 @@ class VelocityKernel(Kernel):
             gene_subset=gene_subset,
             compute_cond_num=compute_cond_num,
             check_connectivity=check_connectivity,
+            **kwargs,
         )
         self._vkey = vkey  # for copy
         self._xkey = xkey

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -106,6 +106,8 @@ def compare(
             fpath += ".png"
         if dirname is not None:
             for file in os.listdir(FIGS / dirname):
+                if "-diff" in file:
+                    continue
                 _compare_images(GT_FIGS / dirname / file, FIGS / dirname / file)
         else:
             _compare_images(GT_FIGS / fpath, FIGS / fpath)


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Clearly and concisely describe your changes. -->
Fix reading connectivities in kernels (previously, connectivities for dens. norm was not accesible for some kernels).
Note that `cr.tl.kernels.ConnectivityKernel(adata, conn_key='neighbors')` will work iff
`scanpy.pp.neighbors(adata, key_added='neighbors')` was run before, not if `scanpy.pp.neighbors(adata, key_added=None)`
(both write `adata.uns['neighbors']`, but `conn_key` really looks into `adata.obsp`.

## How has this been tested?
<!--- Describe in detail how you've tested your changes. -->
Yes, new test to see if all kernels can correctly read the connectivities.

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #589 