### PR TITLE
Exp time kernel

### DIFF
--- a/cellrank/external/kernels/__init__.py
+++ b/cellrank/external/kernels/__init__.py
@@ -1,2 +1,2 @@
 from cellrank.external.kernels._wot_kernel import WOTKernel
-from cellrank.external.kernels._statot_kernel import OTKernel
+from cellrank.external.kernels._statot_kernel import StationaryOTKernel

--- a/cellrank/external/kernels/__init__.py
+++ b/cellrank/external/kernels/__init__.py
@@ -1,1 +1,2 @@
+from cellrank.external.kernels._wot_kernel import WOTKernel
 from cellrank.external.kernels._statot_kernel import OTKernel

--- a/cellrank/external/kernels/_statot_kernel.py
+++ b/cellrank/external/kernels/_statot_kernel.py
@@ -23,7 +23,7 @@ except ImportError as e:
 
 
 @d.dedent
-class OTKernel(OTKernel_, error=_error):
+class StationaryOTKernel(OTKernel_, error=_error):
     """
     Stationary optimal transport kernel from [Zhang21]_.
 
@@ -76,7 +76,7 @@ class OTKernel(OTKernel_, error=_error):
         C: Optional[np.ndarray] = None,
         verbose: bool = False,
         **kwargs: Any,
-    ) -> "OTKernel":
+    ) -> "StationaryOTKernel":
         """
         Compute transition matrix using stationary OT [Zhang21]_.
 
@@ -113,7 +113,7 @@ class OTKernel(OTKernel_, error=_error):
 
         Returns
         -------
-        :class:`cellrank.external.kernels.OTKernel`
+        :class:`cellrank.external.kernels.StationaryOTKernel`
             Makes :attr:`transition_matrix` available.
         """
         if method not in ("ent", "quad", "unbal"):

--- a/cellrank/external/kernels/_wot_kernel.py
+++ b/cellrank/external/kernels/_wot_kernel.py
@@ -37,7 +37,7 @@ class WOTKernel(Kernel, error=_error):
     """
     Waddington optimal transport kernel from [Schiebinger19]_.
 
-    This class requires the `wot` package, which can be installed `pip install wot`.
+    This class requires the `wot` package, which can be installed `pip install git+https://github.com/broadinstitute/wot`.
 
     Parameters
     ----------
@@ -47,7 +47,7 @@ class WOTKernel(Kernel, error=_error):
         Key in :attr:`adata` ``.obs`` where experimental time is stored.
         The experimental time can be of either of a numeric or an ordered categorical type.
     %(cond_num)s
-    """
+    """  # noqa: E501
 
     def __init__(
         self,

--- a/cellrank/external/kernels/_wot_kernel.py
+++ b/cellrank/external/kernels/_wot_kernel.py
@@ -47,6 +47,34 @@ class WOTKernel(Kernel, error=_error):
         Key in :attr:`adata` ``.obs`` where experimental time is stored.
         The experimental time can be of either of a numeric or an ordered categorical type.
     %(cond_num)s
+
+    Examples
+    --------
+    Workflow::
+
+        import scanpy as sc
+        import cellrank as cr
+        from cellrank.external.kernels import WOTKernel
+
+        adata = cr.datasets.lung()
+
+        # filter, normalize and annotate hvg's
+        sc.pp.filter_genes(adata, min_cells=10)
+        sc.pp.normalize_total(adata)
+        sc.pp.log1p(adata)
+        sc.pp.highly_variable_genes(adata)
+
+        # estimate proliferation and apoptosis from gene sets (see. e.g. WOT tutorial for example lists)
+        sc.tl.score_genes(adata, gene_list=proliferation_genes, score_name='proliferation')
+        sc.tl.score_genes(adata, gene_list=apoptosis_genes, score_name='apoptosis')
+
+        # initialize kernel, estimate initial growth rate based on scores from above
+        ot = WOTKernel(adata, time_key='day')
+        ot.compute_initial_growth_rates(proliferation_key='proliferation', apoptosis_key='apoptosis',
+                                 key_added='initial_growth_rates')
+
+        # compute transport maps, aggregate into one single transition matrix
+        ot.compute_transition_matrix(growth_rate_key='initial_growth_rates', growth_iters=3)
     """  # noqa: E501
 
     __import_error_message__ = (

--- a/cellrank/external/kernels/_wot_kernel.py
+++ b/cellrank/external/kernels/_wot_kernel.py
@@ -37,7 +37,8 @@ class WOTKernel(Kernel, error=_error):
     """
     Waddington optimal transport kernel from [Schiebinger19]_.
 
-    This class requires the `wot` package, which can be installed `pip install git+https://github.com/broadinstitute/wot`.
+    This class requires the `wot` package, which can be installed as
+    `pip install git+https://github.com/broadinstitute/wot`.
 
     Parameters
     ----------
@@ -58,24 +59,27 @@ class WOTKernel(Kernel, error=_error):
 
         adata = cr.datasets.lung()
 
-        # filter, normalize and annotate hvg's
+        # filter, normalize and annotate HVGs
         sc.pp.filter_genes(adata, min_cells=10)
         sc.pp.normalize_total(adata)
         sc.pp.log1p(adata)
         sc.pp.highly_variable_genes(adata)
 
         # estimate proliferation and apoptosis from gene sets (see. e.g. WOT tutorial for example lists)
+        proliferation_genes = ...
+        apoptosis_genes = ...
         sc.tl.score_genes(adata, gene_list=proliferation_genes, score_name='proliferation')
         sc.tl.score_genes(adata, gene_list=apoptosis_genes, score_name='apoptosis')
 
         # initialize kernel, estimate initial growth rate based on scores from above
         ot = WOTKernel(adata, time_key='day')
-        ot.compute_initial_growth_rates(proliferation_key='proliferation', apoptosis_key='apoptosis',
-                                 key_added='initial_growth_rates')
+        ot.compute_initial_growth_rates(proliferation_key='proliferation',
+                                        apoptosis_key='apoptosis',
+                                        key_added='initial_growth_rates')
 
         # compute transport maps, aggregate into one single transition matrix
         ot.compute_transition_matrix(growth_rate_key='initial_growth_rates', growth_iters=3)
-    """  # noqa: E501
+    """
 
     __import_error_message__ = (
         "Unable to import the kernel. Please install `wot` first as "
@@ -150,7 +154,8 @@ class WOTKernel(Kernel, error=_error):
         be saved in :attr:`adata` ``.obs``. These rates are usually computed based on a gene set using a scoring
         function like :func:`scanpy.tl.score_genes`. If you don't have access to such gene sets, don't worry,
         you can use WOT without an estimate of initial growth rates.
-        To learn more, please see WOT's official `tutorial <https://broadinstitute.github.io/wot/tutorial/>`_.
+
+        For more information about WOT, see the official `tutorial <https://broadinstitute.github.io/wot/tutorial/>`_.
         """
 
         def logistic(x: np.ndarray, L: float, k: float, x0: float = 0) -> np.ndarray:
@@ -216,7 +221,7 @@ class WOTKernel(Kernel, error=_error):
         ----------
         cost_matrices
             Cost matrices for each consecutive pair of time points.
-            If a :class:`str`, it specifies a key in :attr:`adata` ``.layers``: or :attr:`adata` ``.obsm``
+            If a :class:`str`, it specifies a key in :attr:`adata` ``.layers`` or :attr:`adata` ``.obsm``
             containing cell features that are used to compute cost matrices. If `None`, use `WOT`'s default, i.e.
             compute distances in PCA space derived from :attr:`adata` ``.X`` for each time point pair separately.
         lambda1
@@ -233,12 +238,12 @@ class WOTKernel(Kernel, error=_error):
             Which solver to use.
         growth_rate_key
             Key in :attr:`adata` ``.obs`` where initial cell growth rates are stored.
-            See :meth:`cellrank.external.kernels.WOTKernel.compute_initial_growth_rates` to estimate them from data.
+            See :meth:`cellrank.external.kernels.WOTKernel.compute_initial_growth_rates` on how to estimate them.
         use_highly_variable
             Key in :attr:`adata` ``.var`` where highly variable genes are stored.
             If `True`, use `'highly_variable'`. If `None`, use all genes.
         uniform
-            If `True`, use normalized matrix of 1s for the transitions within the last time point.
+            If `True`, use row-normalized matrix of 1s for transitions within the last time point.
             Otherwise, use diagonal matrix with 1s on the diagonal.
         kwargs
             Additional keyword arguments for OT configuration.
@@ -247,7 +252,7 @@ class WOTKernel(Kernel, error=_error):
         -------
         :class:`cellrank.external.kernels.WOTKernel`
             Makes :attr:`transition_matrix`, :attr:`transition_maps` and :attr:`growth_rates` available.
-            It also  modifies :attr:`anndata.AnnData.obs` with the following key:
+            It also modifies :attr:`anndata.AnnData.obs` with the following key:
 
                 - `'estimated_growth_rates'` - the estimated final growth rates.
 

--- a/cellrank/external/kernels/_wot_kernel.py
+++ b/cellrank/external/kernels/_wot_kernel.py
@@ -119,6 +119,9 @@ class WOTKernel(Kernel, error=_error):
         -------
         :class:`cellrank.external.kernels.WOTKernel`
             Makes :attr:`transition_matrix`, :attr:`transition_maps` and :attr:`growth_rates` available.
+            It also  modifies :attr:`anndata.AnnData.obs` with the following key:
+
+                - `'estimated_growth_rates'` - the estimated growth rates based on ``growth_iters``.
 
         Notes
         -----
@@ -163,6 +166,7 @@ class WOTKernel(Kernel, error=_error):
             density_normalize=False,
             check_irreducibility=False,
         )
+        self.adata.obs["estimated_growth_rates"] = self.growth_rates[f"g{growth_iters}"]
 
         logg.info("    Finish", time=start)
 

--- a/cellrank/external/kernels/_wot_kernel.py
+++ b/cellrank/external/kernels/_wot_kernel.py
@@ -1,0 +1,13 @@
+from cellrank.tl.kernels import ExperimentalTimeKernel
+
+
+class WOTKernel(ExperimentalTimeKernel):
+    """Kernel based on Waddington optimal transport [Schiebinger19]_."""
+
+    def __init__(self, *args, **kwargs):
+        # TODO: test for wot import
+        super().__init__(*args, **kwargs)
+
+    def compute_transition_matrix(self, *args, **kwargs) -> "WOTKernel":
+        """TODO."""
+        return self

--- a/cellrank/external/kernels/_wot_kernel.py
+++ b/cellrank/external/kernels/_wot_kernel.py
@@ -1,13 +1,298 @@
-from cellrank.tl.kernels import ExperimentalTimeKernel
+from typing import Any, Dict, Tuple, Union, Mapping, Optional
+
+from tqdm.auto import tqdm
+from typing_extensions import Literal
+
+from anndata import AnnData
+
+import numpy as np
+import pandas as pd
+from scipy.sparse import bmat, spdiags, spmatrix
+
+from cellrank import logging as logg
+from cellrank.ul._docs import d
+from cellrank.tl._utils import _normalize
+
+_error = None
+try:
+    import wot
+
+    from cellrank.tl.kernels import ExperimentalTimeKernel as Kernel
+except ImportError as e:
+    from cellrank.external.kernels._import_error_kernel import ErroredKernel as Kernel
+
+    _error = e
+    wot = None
 
 
-class WOTKernel(ExperimentalTimeKernel):
-    """Kernel based on Waddington optimal transport [Schiebinger19]_."""
+class nstr(str):  # used for params+cache (precomputed cost matrices)
+    """String class that is not equal to any other string."""
 
-    def __init__(self, *args, **kwargs):
-        # TODO: test for wot import
-        super().__init__(*args, **kwargs)
+    def __eq__(self, other: str) -> bool:
+        return False
 
-    def compute_transition_matrix(self, *args, **kwargs) -> "WOTKernel":
-        """TODO."""
+
+@d.dedent
+class WOTKernel(Kernel, error=_error):
+    """
+    Waddington optimal transport kernel from [Schiebinger19]_.
+
+    This class requires the `wot` package, which can be installed `pip install wot`.
+
+    Parameters
+    ----------
+    %(adata)s
+    %(backward)s
+    time_key
+        Key in :attr:`adata` ``.obs`` where experimental time is stored.
+        The experimental time can be of either of a numeric or an ordered categorical type.
+    %(cond_num)s
+    """
+
+    def __init__(
+        self,
+        adata: AnnData,
+        backward: bool = False,
+        time_key: str = "exp_time",
+        compute_cond_num: bool = False,
+    ):
+        super().__init__(
+            adata,
+            backward=backward,
+            time_key=time_key,
+            compute_cond_num=compute_cond_num,
+        )
+
+        # WOT's requirements
+        cats = self.experimental_time.cat.categories
+        self._exp_time = self.experimental_time.cat.rename_categories(
+            dict(zip(cats, map(float, cats)))
+        )
+        self.adata.obs[self._time_key] = self.experimental_time
+        self._growth_rates = None
+
+    def compute_transition_matrix(
+        self,
+        cost_matrices: Optional[
+            Union[str, Mapping[Tuple[float, float], np.ndarray]]
+        ] = None,
+        solver: Literal["fixed_iters", "duality_gap"] = "duality_gap",
+        growth_rate_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "WOTKernel":
+        """
+        Compute transition matrix using Waddington OT [Schiebinger19]_.
+
+        Parameters
+        ----------
+        cost_matrices
+            Cost matrices for each consecutive time pair.
+            If a :class:`str`, it specifies a key in :attr:`adata` ``.layers``: or :attr:`adata` ``.obsm``
+            containing cell features that are used to compute cost matrices.
+            If `None`, use `WOT`'s default.
+        solver
+            Which solver to use.
+        growth_rate_key
+            Key in :attr:`adata` ``.obs`` where initial cell growth rates are stored.
+        kwargs
+            Keyword arguments for OT configuration.
+
+        Returns
+        -------
+        :class:`cellrank.external.kernels.WOTKernel`
+            Makes :attr:`transition_matrix` and :attr:`growth_rates` available.
+        """
+        # disallow these params (because they e.g. subset the data)
+        _ = kwargs.pop("cell_day_filter", None)
+        _ = kwargs.pop("covariate_field", None)
+        _ = kwargs.pop("ncounts", None)
+        _ = kwargs.pop("ncells", None)
+        kwargs.setdefault("epsilon", 0.05)
+        kwargs.setdefault("lambda1", 1)
+        kwargs.setdefault("lamdda2", 50)
+        kwargs["growth_iters"] = max(kwargs.get("growth_iters"), 1)
+
+        start = logg.info(
+            "Computing transition matrix using Waddington Optimal Transport"
+        )
+
+        cost_matrices, cmat_param = self._generate_cost_matrices(cost_matrices)
+        if self._reuse_cache(
+            {
+                "cost_matrices": cmat_param,
+                "solver": solver,
+                "growth_rate_key": growth_rate_key,
+                **kwargs,
+            },
+            time=start,
+        ):
+            return self
+
+        tmat = self._compute_pairwise_tmats(
+            cost_matrices=cost_matrices,
+            solver=solver,
+            growth_rate_field=growth_rate_key,
+            **kwargs,
+        )
+        tmat = self._restich_tmats(tmat)
+
+        self._compute_transition_matrix(
+            matrix=tmat,
+            density_normalize=False,
+            check_irreducibility=False,
+        )
+
+        logg.info("    Finish", time=start)
+
         return self
+
+    def _compute_pairwise_tmats(
+        self,
+        cost_matrices: Optional[
+            Union[str, Mapping[Tuple[float, float], np.ndarray]]
+        ] = None,
+        solver: Literal["fixed_iters", "duality_gap"] = "duality_gap",
+        growth_rate_field: Optional[str] = None,
+        **kwargs,
+    ) -> Dict[Tuple[float, float], AnnData]:
+        self._ot_model = wot.ot.OTModel(
+            self.adata,
+            day_field=self._time_key,
+            covariate_field=None,
+            growth_rate_field=growth_rate_field,
+            solver=solver,
+            **kwargs,
+        )
+
+        tmats: Dict[Tuple[float, float], AnnData] = {}
+        start = logg.info(
+            f"Computing transport maps for `{len(cost_matrices)}` time pairs"
+        )
+        for tpair, cost_matrix in tqdm(cost_matrices.items(), unit="time pair"):
+            tmat: AnnData = self._ot_model.compute_transport_map(
+                *tpair, cost_matrix=cost_matrix
+            )
+            nans = int(np.sum(np.isnan(tmat.X)))
+            if nans:
+                raise ValueError(
+                    f"Encountered `{nans}` NaN values for time pair `{tpair}`."
+                )
+            tmat.X = _normalize(tmat.X)
+            tmats[tpair] = tmat
+
+        logg.info("    Finish", time=start)
+
+        return tmats
+
+    def _restich_tmats(self, tmaps: Mapping[Union[float, float], AnnData]) -> spmatrix:
+        blocks = [[None] * (len(tmaps) + 1) for _ in range(len(tmaps) + 1)]
+        nrows, ncols = 0, 0
+        obs_names, growth_rates = [], []
+
+        for i, tmap in enumerate(tmaps.values()):
+            blocks[i][i + 1] = tmap.X
+            nrows += tmap.n_obs
+            ncols += tmap.n_vars
+            obs_names.extend(tmap.obs_names)
+            growth_rates.append(tmap.obs)
+        obs_names.extend(tmap.var_names)
+
+        n = self.adata.n_obs - nrows
+        blocks[-1][-1] = spdiags([1] * n, 0, n, n)
+        n = blocks[0][1].shape[0]
+        blocks[0][0] = spdiags([], 0, n, n)
+
+        tmp = AnnData(bmat(blocks, format="csr"))
+        tmp.obs_names = obs_names
+        tmp.var_names = obs_names
+        tmp = tmp[self.adata.obs_names, :][:, self.adata.obs_names]
+
+        self._growth_rates = pd.merge(
+            tmp.obs,
+            pd.concat(growth_rates),
+            left_index=True,
+            right_index=True,
+            how="left",
+        )
+
+        return tmp.X
+
+    def _generate_cost_matrices(
+        self,
+        cost_matrices: Optional[
+            Union[str, Mapping[Tuple[float, float], np.ndarray]]
+        ] = None,
+    ) -> Tuple[Mapping[Tuple[float, float], Optional[np.ndarray]], str]:
+        timepoints = self.experimental_time.cat.categories
+        timepoints = list(zip(timepoints[:-1], timepoints[1:]))
+
+        if cost_matrices is None:
+            logg.debug("Using default cost matrices")
+            return {tpair: None for tpair in timepoints}, "default"
+
+        if isinstance(cost_matrices, dict):
+            logg.debug("Using precomputed cost matrices")
+
+            cmats = {}
+            for tpair in timepoints:
+                if tpair not in cost_matrices:
+                    logg.warning(
+                        f"Unable to find cost matrix for pair `{tpair}`. Using default"
+                    )
+                cmats[tpair] = cmat = cost_matrices.get(tpair, None)
+                if cmat is not None:
+                    n_start = len(np.where(self.experimental_time == tpair[0])[0])
+                    n_end = len(np.where(self.experimental_time == tpair[1])[0])
+                    try:
+                        if cmat.shape != (n_start, n_end):
+                            raise ValueError(
+                                f"Expected cost matrix for time pair `{tpair}` to be "
+                                f"of shape `{(n_start, n_end)}`, found `{cmat.shape}`."
+                            )
+                    except AttributeError:
+                        logg.warning(
+                            f"Unable to verify whether supplied cost matrix for time pair `{tpair}` "
+                            f"has the correct shape `{(n_start, n_end)}`"
+                        )
+
+            # prevent equality comparison when comparing with cache
+            return cmats, nstr("precomputed")
+
+        if isinstance(cost_matrices, str):
+            logg.debug(f"Computing cost matrices using `{cost_matrices!r}` key")
+            if cost_matrices == "X":
+                cost_matrices = None
+
+            try:
+                features = self.adata._get_X(layer=cost_matrices)
+                modifier = "layer"
+            except KeyError:
+                try:
+                    features = self.adata.obsm[cost_matrices]
+                    modifier = "obsm"
+                except KeyError:
+                    raise KeyError(
+                        f"Unable to find key `{cost_matrices!r}` in `adata.layers` or `adata.obsm`."
+                    ) from None
+
+            cmats = {}
+            for tpair in timepoints:
+                start_ixs = np.where(self.experimental_time == tpair[0])[0]
+                end_ixs = np.where(self.experimental_time == tpair[1])[0]
+
+                # being sparse is handled in WOT's function below
+                cmats[tpair] = wot.ot.OTModel.compute_default_cost_matrix(
+                    features[start_ixs], features[end_ixs]
+                )
+
+            return cmats, f"{modifier}:{cost_matrices}"
+
+        raise NotImplementedError(
+            f"Specifying cost matrices as "
+            f"`{type(cost_matrices).__name__}` is not yet implemented."
+        )
+
+    @property
+    def growth_rates(self) -> Optional[pd.DataFrame]:
+        """Estimated cell growth rates for each growth rate iteration."""
+        return self._growth_rates

--- a/cellrank/tl/_utils.py
+++ b/cellrank/tl/_utils.py
@@ -758,7 +758,9 @@ def _symmetric(
     return d_norm((matrix - matrix.T), ord=ord) < eps
 
 
-def _normalize(X: Union[np.ndarray, spmatrix]) -> Union[np.ndarray, spmatrix]:
+def _normalize(
+    X: Union[np.ndarray, spmatrix], eps: float = 1e-12
+) -> Union[np.ndarray, spmatrix]:
     """
     Row-normalizes an array to sum to 1.
 
@@ -766,6 +768,8 @@ def _normalize(X: Union[np.ndarray, spmatrix]) -> Union[np.ndarray, spmatrix]:
     ----------
     X
         Array to be normalized.
+    eps
+        To avoid division by zero.
 
     Returns
     -------
@@ -776,9 +780,9 @@ def _normalize(X: Union[np.ndarray, spmatrix]) -> Union[np.ndarray, spmatrix]:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         if issparse(X):
-            return X.multiply(csr_matrix(1.0 / np.abs(X).sum(1)))
+            return X.multiply(csr_matrix(1.0 / (np.abs(X).sum(1) + eps)))
         X = np.array(X)
-        return X / X.sum(1)[:, None]
+        return X / (X.sum(1)[:, None] + eps)
 
 
 def _get_connectivities(

--- a/cellrank/tl/kernels/__init__.py
+++ b/cellrank/tl/kernels/__init__.py
@@ -1,4 +1,5 @@
 from cellrank.tl.kernels._base_kernel import Kernel
+from cellrank.tl.kernels._exp_time_kernel import ExperimentalTimeKernel
 from cellrank.tl.kernels._velocity_kernel import VelocityKernel
 from cellrank.tl.kernels._cytotrace_kernel import CytoTRACEKernel
 from cellrank.tl.kernels._velocity_schemes import (

--- a/cellrank/tl/kernels/_base_kernel.py
+++ b/cellrank/tl/kernels/_base_kernel.py
@@ -166,13 +166,15 @@ class KernelExpression(Pickleable, ABC):
             )
 
     @abstractmethod
-    def compute_transition_matrix(self, *args, **kwargs) -> "KernelExpression":
+    def compute_transition_matrix(
+        self, *args: Any, **kwargs: Any
+    ) -> "KernelExpression":
         """
         Compute a transition matrix.
 
         Parameters
         ----------
-        *args
+        args
             Positional arguments.
         kwargs
             Keyword arguments.

--- a/cellrank/tl/kernels/_base_kernel.py
+++ b/cellrank/tl/kernels/_base_kernel.py
@@ -274,7 +274,7 @@ class KernelExpression(Pickleable, ABC):
         Parameters
         ----------
         basis
-            Basis in :attr:`anndata.AnnData.obsm` for which to compute the projection.
+            Basis in :attr:`adata` ``.obsm`` for which to compute the projection.
         key_added
             If not `None` and ``copy=False``, save the result to :attr:`adata` ``.obsm['{key_added}']``.
             Otherwise, save the result to `'T_fwd_{basis}'` or `T_bwd_{basis}`, depending on the direction.
@@ -905,6 +905,14 @@ class Kernel(UnaryKernelExpression, ABC):
         density_normalize: bool = True,
         check_irreducibility: bool = False,
     ):
+        if matrix.shape[0] != matrix.shape[1]:
+            raise ValueError(f"Expected a square matrix, found `{matrix.shape}`.")
+        if matrix.shape[0] != self.adata.n_obs:
+            raise ValueError(
+                f"Expected matrix to be of shape `{(self.adata.n_obs, self.adata.n_obs)}`, "
+                f"found `{matrix.shape}`."
+            )
+
         matrix = matrix.astype(_dtype)
         if issparse(matrix) and not isspmatrix_csr(matrix):
             matrix = csr_matrix(matrix)

--- a/cellrank/tl/kernels/_exp_time_kernel.py
+++ b/cellrank/tl/kernels/_exp_time_kernel.py
@@ -109,9 +109,12 @@ class ExperimentalTimeKernel(Kernel, ABC):
 
     def __invert__(self) -> "ExperimentalTimeKernel":
         super().__invert__()
-        if len(self.experimental_time.categories) > 1:
+        if len(self.experimental_time.cat.categories) > 1:
             minn, maxx = self.experimental_time.min(), self.experimental_time.max()
-            self._exp_time = pd.Categorical(
-                maxx - np.array(self.experimental_time) + minn, ordered=True
+            self._exp_time = pd.Series(
+                pd.Categorical(
+                    maxx - np.array(self.experimental_time) + minn, ordered=True
+                ),
+                index=self.experimental_time.index,
             )
         return self

--- a/cellrank/tl/kernels/_exp_time_kernel.py
+++ b/cellrank/tl/kernels/_exp_time_kernel.py
@@ -81,7 +81,7 @@ class ExperimentalTimeKernel(Kernel, ABC):
             )
 
         if not exp_time.cat.ordered:
-            logg.warning("Time categories are not ordered. Using default order")
+            logg.warning("Time categories are not ordered. Using ascending order")
             exp_time.cat = exp_time.cat.as_ordered()
 
         self._exp_time = pd.Series(

--- a/cellrank/tl/kernels/_exp_time_kernel.py
+++ b/cellrank/tl/kernels/_exp_time_kernel.py
@@ -1,0 +1,116 @@
+"""Experimental time kernel module."""
+from abc import ABC
+from copy import copy
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import infer_dtype
+from pandas.core.dtypes.common import (
+    is_object_dtype,
+    is_numeric_dtype,
+    is_categorical_dtype,
+)
+
+from cellrank import logging as logg
+from cellrank.ul._docs import d
+from cellrank.tl.kernels import Kernel
+from cellrank.tl.kernels._base_kernel import AnnData
+
+
+@d.dedent
+class ExperimentalTimeKernel(Kernel, ABC):
+    """
+    Base kernel class which computes directed transition probabilities based on experimental time.
+
+    %(density_correction)s
+
+    Parameters
+    ----------
+    %(adata)s
+    %(backward)s
+    time_key
+        Key in :paramref:`adata` ``.obs`` where the experimental time is stored.
+        The experimental time can be of either a numeric or an ordered categorical type.
+    compute_cond_num
+        Whether to compute condition number of the transition matrix. Note that this might be costly,
+        since it does not use sparse implementation.
+    """
+
+    def __init__(
+        self,
+        adata: AnnData,
+        backward: bool = False,
+        time_key: str = "exp_time",
+        compute_cond_num: bool = False,
+        check_connectivity: bool = False,
+    ):
+        super().__init__(
+            adata,
+            backward=backward,
+            time_key=time_key,
+            compute_cond_num=compute_cond_num,
+            check_connectivity=check_connectivity,
+        )
+        self._time_key = time_key
+
+    def _read_from_adata(self, **kwargs: Any) -> None:
+        super()._read_from_adata(**kwargs)
+
+        time_key = kwargs.pop("time_key", "exp_time")
+        if time_key not in self.adata.obs.keys():
+            raise KeyError(f"Could not find time key in `adata.obs[{time_key!r}]`.")
+
+        exp_time = self.adata.obs[time_key].copy()
+        if not is_categorical_dtype(exp_time):
+            exp_time = np.array(exp_time)
+            if is_object_dtype(exp_time):
+                try:
+                    exp_time = exp_time.astype(float)
+                except ValueError as e:
+                    raise RuntimeError(
+                        f"Unable to convert `adata.obs[{time_key!r}]` to `float` dtype."
+                    ) from e
+            if not is_numeric_dtype(exp_time):
+                raise TypeError(
+                    f"Expected experimental time to be `numeric` or `categorical`, found `{infer_dtype(exp_time)}`."
+                )
+            exp_time = pd.Series(
+                pd.Categorical(
+                    exp_time,
+                    categories=sorted(set(exp_time[~np.isnan(exp_time)])),
+                    ordered=True,
+                )
+            )
+
+        if not exp_time.cat.ordered:
+            logg.warning("Ordering categories")
+            exp_time.cat = exp_time.cat.as_ordered()
+
+        self._exp_time = pd.Categorical(exp_time, ordered=True)
+
+    @property
+    def experimental_time(self) -> pd.Categorical:
+        """Experimental time."""
+        return self._exp_time
+
+    def copy(self) -> "ExperimentalTimeKernel":
+        """Return a copy of self."""
+        pk = ExperimentalTimeKernel(
+            self.adata, backward=self.backward, time_key=self._time_key
+        )
+        pk._exp_time = copy(self.experimental_time)
+        pk._params = copy(self._params)
+        pk._cond_num = self.condition_number
+        pk._transition_matrix = copy(self._transition_matrix)
+
+        return pk
+
+    def __invert__(self) -> "ExperimentalTimeKernel":
+        super().__invert__()
+        if len(self.experimental_time.categories) > 1:
+            minn, maxx = self.experimental_time.min(), self.experimental_time.max()
+            self._exp_time = pd.Categorical(
+                maxx - np.array(self.experimental_time) + minn, ordered=True
+            )
+        return self

--- a/docs/source/classes.rst
+++ b/docs/source/classes.rst
@@ -112,14 +112,18 @@ Base Classes
 
 BaseEstimator
 -------------
-
 .. autoclass:: cellrank.tl.estimators.BaseEstimator
     :members:
 
 Kernel
 ------
-
 .. autoclass:: cellrank.tl.kernels.Kernel
+    :members:
+    :inherited-members:
+
+ExperimentalTimeKernel
+----------------------
+.. autoclass:: cellrank.tl.kernels.ExperimentalTimeKernel
     :members:
     :inherited-members:
 

--- a/docs/source/classes.rst
+++ b/docs/source/classes.rst
@@ -12,7 +12,6 @@ GPCCA
 
 CFLARE
 ------
-
 .. autoclass:: cellrank.tl.estimators.CFLARE
     :members:
     :inherited-members:
@@ -22,64 +21,54 @@ Kernels
 
 Velocity Kernel
 ---------------
-
 .. autoclass:: cellrank.tl.kernels.VelocityKernel
     :members:
 
 Cosine similarity scheme
 ++++++++++++++++++++++++
-
 .. autoclass:: cellrank.tl.kernels.CosineScheme
     :members: __call__, hessian
 
 Correlation scheme
 ++++++++++++++++++
-
 .. autoclass:: cellrank.tl.kernels.CorrelationScheme
     :members: __call__, hessian
 
 Dot product scheme
 ++++++++++++++++++
-
 .. autoclass:: cellrank.tl.kernels.DotProductScheme
     :members: __call__, hessian
 
 
 Connectivity Kernel
 -------------------
-
 .. autoclass:: cellrank.tl.kernels.ConnectivityKernel
     :members:
 
 Pseudotime Kernel
 -----------------
-
 .. autoclass:: cellrank.tl.kernels.PseudotimeKernel
     :members:
 
 Hard threshold scheme
 +++++++++++++++++++++
-
 .. autoclass:: cellrank.tl.kernels.HardThresholdScheme
     :members:
     :special-members: __call__
 
 Soft threshold scheme
 +++++++++++++++++++++
-
 .. autoclass:: cellrank.tl.kernels.SoftThresholdScheme
     :members:
     :special-members: __call__
 
 CytoTRACE Kernel
 ----------------
-
 .. autoclass:: cellrank.tl.kernels.CytoTRACEKernel
     :members: compute_cytotrace, compute_transition_matrix
 
 Precomputed Kernel
 ------------------
-
 .. autoclass:: cellrank.tl.kernels.PrecomputedKernel
     :members:
 
@@ -88,21 +77,18 @@ Models
 
 GAM
 ---
-
 .. autoclass:: cellrank.ul.models.GAM
     :members:
     :inherited-members:
 
 SKLearnModel
 ------------
-
 .. autoclass:: cellrank.ul.models.SKLearnModel
     :members:
     :inherited-members:
 
 GAMR
 ----
-
 .. autoclass:: cellrank.ul.models.GAMR
     :members:
     :inherited-members:
@@ -129,7 +115,6 @@ ExperimentalTimeKernel
 
 Similarity scheme
 -----------------
-
 .. autoclass:: cellrank.tl.kernels.SimilaritySchemeABC
     :members:
     :special-members: __call__
@@ -145,12 +130,10 @@ Threshold scheme
 
 BaseModel
 ---------
-
 .. autoclass:: cellrank.ul.models.BaseModel
     :members:
 
 Lineage
 -------
-
 .. autoclass:: cellrank.tl.Lineage
     :members: priming_degree, reduce, plot_pie, X, T, view, names, colors

--- a/docs/source/external_api.rst
+++ b/docs/source/external_api.rst
@@ -14,6 +14,7 @@ Kernels
     :toctree: api
 
     external.kernels.OTKernel
+    external.kernels.WOTKernel
 
 Estimators
 ~~~~~~~~~~

--- a/docs/source/external_api.rst
+++ b/docs/source/external_api.rst
@@ -13,7 +13,7 @@ Kernels
 .. autosummary::
     :toctree: api
 
-    external.kernels.OTKernel
+    external.kernels.StationaryOTKernel
     external.kernels.WOTKernel
 
 Estimators

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -66,6 +66,10 @@ References
     *A scaling normalization method for differential expression analysis of RNA-seq data*,
     `Genome Biology <https://doi.org/10.1186/gb-2010-11-3-r25>`__.
 
+.. [Schiebinger19] Schiebinger *et al.* (2019)
+    *Optimal-Transport Analysis of Single-Cell Gene Expression Identifies Developmental Trajectories in Reprogramming*,
+    `Cell <https://doi.org/10.1016/j.cell.2019.01.006>`__.
+
 .. [Setty19] Setty *et al.* (2019),
     *Characterization of cell fate probabilities in single-cell data with Palantir*,
     `Nature Biotechnology <https://doi.org/10.1038/s41587-019-0068-4>`__.

--- a/qgq
+++ b/qgq
@@ -1,0 +1,103 @@
+[1mdiff --git a/cellrank/external/kernels/_wot_kernel.py b/cellrank/external/kernels/_wot_kernel.py[m
+[1mindex c8b45bf..3ada518 100644[m
+[1m--- a/cellrank/external/kernels/_wot_kernel.py[m
+[1m+++ b/cellrank/external/kernels/_wot_kernel.py[m
+[36m@@ -173,6 +173,7 @@[m [mclass WOTKernel(Kernel, error=_error):[m
+         solver: Literal["fixed_iters", "duality_gap"] = "duality_gap",[m
+         growth_rate_key: Optional[str] = None,[m
+         use_highly_variable: Optional[Union[str, bool]] = True,[m
+[32m+[m[32m        uniform: bool = False,[m
+         **kwargs: Any,[m
+     ) -> "WOTKernel":[m
+         """[m
+[36m@@ -208,6 +209,9 @@[m [mclass WOTKernel(Kernel, error=_error):[m
+         use_highly_variable[m
+             Key in :attr:`adata` ``.var`` where highly variable genes are stored.[m
+             If `True`, use `'highly_variable'`. If `None`, use all genes.[m
+[32m+[m[32m        uniform[m
+[32m+[m[32m            If `True`, use normalized matrix of 1s for the transitions within the last time point.[m
+[32m+[m[32m            Otherwise, use diagonal matrix with 1s on the diagonal.[m
+         kwargs[m
+             Additional keyword arguments for OT configuration.[m
+ [m
+[36m@@ -258,7 +262,7 @@[m [mclass WOTKernel(Kernel, error=_error):[m
+             growth_rate_field=growth_rate_key,[m
+             **kwargs,[m
+         )[m
+[31m-        tmat = self._restich_tmats(tmat)[m
+[32m+[m[32m        tmat = self._restich_tmats(tmat, uniform)[m
+ [m
+         self._compute_transition_matrix([m
+             matrix=tmat,[m
+[36m@@ -309,7 +313,7 @@[m [mclass WOTKernel(Kernel, error=_error):[m
+ [m
+         return self._tmats[m
+ [m
+[31m-    def _restich_tmats(self, tmaps: Mapping[Tuple[float, float], AnnData]) -> spmatrix:[m
+[32m+[m[32m    def _restich_tmats(self, tmaps: Mapping[Tuple[float, float], AnnData], uniform: bool = False) -> spmatrix:[m
+         blocks = [[None] * (len(tmaps) + 1) for _ in range(len(tmaps) + 1)][m
+         nrows, ncols = 0, 0[m
+         obs_names, growth_rates = [], [][m
+[36m@@ -323,7 +327,7 @@[m [mclass WOTKernel(Kernel, error=_error):[m
+         obs_names.extend(tmap.var_names)[m
+ [m
+         n = self.adata.n_obs - nrows[m
+[31m-        blocks[-1][-1] = np.ones((n, n)) / float(n)[m
+[32m+[m[32m        blocks[-1][-1] = (np.ones((n, n)) / float(n)) if uniform else spdiags([1] * n, 0, n, n)[m
+         # prevent block from disappearing[m
+         n = blocks[0][1].shape[0][m
+         blocks[0][0] = spdiags([], 0, n, n)[m
+[36m@@ -354,11 +358,11 @@[m [mclass WOTKernel(Kernel, error=_error):[m
+         timepoints = list(zip(timepoints[:-1], timepoints[1:]))[m
+ [m
+         if cost_matrices is None:[m
+[31m-            logg.debug("Using default cost matrices")[m
+[32m+[m[32m            logg.info("Using default cost matrices")[m
+             return {tpair: None for tpair in timepoints}, "default"[m
+ [m
+         if isinstance(cost_matrices, dict):[m
+[31m-            logg.debug("Using precomputed cost matrices")[m
+[32m+[m[32m            logg.info("Using precomputed cost matrices")[m
+ [m
+             cmats = {}[m
+             for tpair in timepoints:[m
+[36m@@ -386,7 +390,7 @@[m [mclass WOTKernel(Kernel, error=_error):[m
+             return cmats, nstr("precomputed")[m
+ [m
+         if isinstance(cost_matrices, str):[m
+[31m-            logg.debug(f"Computing cost matrices using `{cost_matrices!r}` key")[m
+[32m+[m[32m            logg.info(f"Computing cost matrices using `{cost_matrices!r}` key")[m
+             if cost_matrices == "X":[m
+                 cost_matrices = None[m
+ [m
+[1mdiff --git a/tests/test_external.py b/tests/test_external.py[m
+[1mindex 2a0ed18..b96eec0 100644[m
+[1m--- a/tests/test_external.py[m
+[1m+++ b/tests/test_external.py[m
+[36m@@ -54,7 +54,7 @@[m [mclass TestOTKernel:[m
+         assert isinstance(ok.params, dict)[m
+ [m
+ [m
+[31m-@pytest.mark.skip("wot on PyPI doesn't support passing cost matrices")[m
+[32m+[m[32m#@pytest.mark.skip("wot on PyPI doesn't support passing cost matrices")[m
+ class TestWOTKernel:[m
+     def test_inversion_updates_adata(self, adata_large: AnnData):[m
+         key = "age(days)"[m
+[36m@@ -135,6 +135,17 @@[m [mclass TestWOTKernel:[m
+             assert gr is None[m
+             assert "gr" in adata_large.obs[m
+ [m
+[32m+[m[32m    @pytest.mark.parametrize("uniform", [False, True])[m
+[32m+[m[32m    def test_uniform(self, adata_large: AnnData, uniform: bool):[m
+[32m+[m[32m        ok = cre.kernels.WOTKernel(adata_large, time_key="age(days)").compute_transition_matrix(uniform=uniform)[m
+[32m+[m[32m        ixs = np.where(adata_large.obs["age(days)"] == 35.0)[0][m
+[32m+[m
+[32m+[m[32m        T = ok.transition_matrix[ixs, :][:, ixs].A[m
+[32m+[m[32m        if uniform:[m
+[32m+[m[32m            np.testing.assert_allclose(T, np.ones_like(T) / float(len(ixs)))[m
+[32m+[m[32m        else:[m
+[32m+[m[32m            np.testing.assert_allclose(T, np.eye(len(ixs)))[m
+[32m+[m
+     def test_normal_run(self, adata_large: AnnData):[m
+         ok = cre.kernels.WOTKernel(adata_large, time_key="age(days)")[m
+         ok = ok.compute_transition_matrix()[m

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         ),
         extras_require=dict(
             # `POT` is not requirement of `statot`
-            external=["statot>=0.0.14", "POT"],
+            external=["statot>=0.0.14", "POT", "wot"],
             krylov=["pygpcca[slepc]"],
             test=[
                 "pytest>=6.1.1",

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -52,7 +52,7 @@ class TestOTKernel:
         assert isinstance(ok.params, dict)
 
 
-@pytest.mark.skip("wot on PyPI doesn't support passing cost matrices")
+@pytest.mark.skipif("wot on PyPI doesn't support passing cost matrices")
 class TestWOTKernel:
     def test_inversion_updates_adata(self, adata_large: AnnData):
         key = "age(days)"
@@ -123,5 +123,7 @@ class TestWOTKernel:
         np.testing.assert_allclose(ok.transition_matrix.sum(1), 1.0)
         assert isinstance(ok.params, dict)
         assert isinstance(ok.growth_rates, pd.DataFrame)
+        assert isinstance(ok.transition_maps, dict)
         np.testing.assert_array_equal(adata_large.obs_names, ok.growth_rates.index)
         np.testing.assert_array_equal(ok.growth_rates.columns, ["g0", "g1"])
+        assert isinstance(ok.transition_maps[12.0, 35.0], AnnData)

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -112,6 +112,9 @@ class TestWOTKernel:
         np.testing.assert_array_equal(
             ok.growth_rates.columns, [f"g{i}" for i in range(n_iters + 1)]
         )
+        np.testing.assert_array_equal(
+            adata_large.obs["estimated_growth_rates"], ok.growth_rates[f"g{n_iters}"]
+        )
         assert ok.params["growth_iters"] == n_iters
 
     def test_normal_run(self, adata_large: AnnData):

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -52,6 +52,7 @@ class TestOTKernel:
         assert isinstance(ok.params, dict)
 
 
+@pytest.mark.skip("wot on PyPI doesn't support passing cost matrices")
 class TestWOTKernel:
     def test_inversion_updates_adata(self, adata_large: AnnData):
         key = "age(days)"

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -52,7 +52,7 @@ class TestOTKernel:
         assert isinstance(ok.params, dict)
 
 
-@pytest.mark.skipif("wot on PyPI doesn't support passing cost matrices")
+@pytest.mark.skip("wot on PyPI doesn't support passing cost matrices")
 class TestWOTKernel:
     def test_inversion_updates_adata(self, adata_large: AnnData):
         key = "age(days)"

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -18,7 +18,7 @@ class TestOTKernel:
         ixs = np.where(adata_large.obs["clusters"] == "Granule immature")[0]
         terminal_states[ixs] = "GI"
 
-        ok = cre.kernels.OTKernel(
+        ok = cre.kernels.StationaryOTKernel(
             adata_large,
             terminal_states=pd.Series(terminal_states).astype("category"),
             g=np.ones((adata_large.n_obs,), dtype=np.float64),
@@ -31,7 +31,7 @@ class TestOTKernel:
 
     def test_no_terminal_states(self, adata_large: AnnData):
         with pytest.raises(RuntimeError, match="Unable to initialize the kernel."):
-            cre.kernels.OTKernel(
+            cre.kernels.StationaryOTKernel(
                 adata_large,
                 g=np.ones((adata_large.n_obs,), dtype=np.float64),
             )
@@ -41,14 +41,14 @@ class TestOTKernel:
         ixs = np.where(adata_large.obs["clusters"] == "Granule immature")[0]
         terminal_states[ixs] = "GI"
 
-        ok = cre.kernels.OTKernel(
+        ok = cre.kernels.StationaryOTKernel(
             adata_large,
             terminal_states=pd.Series(terminal_states).astype("category"),
             g=np.ones((adata_large.n_obs,), dtype=np.float64),
         )
         ok = ok.compute_transition_matrix(1, 0.001)
 
-        assert isinstance(ok, cre.kernels.OTKernel)
+        assert isinstance(ok, cre.kernels.StationaryOTKernel)
         assert isinstance(ok._transition_matrix, (np.ndarray, spmatrix))
         np.testing.assert_allclose(ok.transition_matrix.sum(1), 1.0)
         assert isinstance(ok.params, dict)

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -135,6 +135,19 @@ class TestWOTKernel:
             assert gr is None
             assert "gr" in adata_large.obs
 
+    @pytest.mark.parametrize("uniform", [False, True])
+    def test_uniform(self, adata_large: AnnData, uniform: bool):
+        ok = cre.kernels.WOTKernel(
+            adata_large, time_key="age(days)"
+        ).compute_transition_matrix(uniform=uniform)
+        ixs = np.where(adata_large.obs["age(days)"] == 35.0)[0]
+
+        T = ok.transition_matrix[ixs, :][:, ixs].A
+        if uniform:
+            np.testing.assert_allclose(T, np.ones_like(T) / float(len(ixs)))
+        else:
+            np.testing.assert_allclose(T, np.eye(len(ixs)))
+
     def test_normal_run(self, adata_large: AnnData):
         ok = cre.kernels.WOTKernel(adata_large, time_key="age(days)")
         ok = ok.compute_transition_matrix()


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Clearly and concisely describe your changes. -->
Add Waddington OT kernel, see related issue https://github.com/broadinstitute/wot/issues/91. I've also added option to use existing obs features (PCA, imputed expression) to compute the cost matrices.
Also adds `ExpTimeKernel` class which can be later used to derive kernels with experimental time.

@Marius1311 I've decided against adding anything to the block diagonal, don't think it's a nice solution - user can always weight with full `ConnectivitiesKernel` and afaik, the GPCCA stability issues were gone (I've used small weights like 0.05 or so for connectivities). Maybe you add some nice note in `.compute_transition_matrix`, below `Returns` as
```
Notes
-----
...
```

## How has this been tested?
<!--- Describe in detail how you've tested your changes. -->
I've added a few.

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #551