### PR TITLE
Update docstring to manually set terminal states

### DIFF
--- a/cellrank/tl/estimators/_base_estimator.py
+++ b/cellrank/tl/estimators/_base_estimator.py
@@ -239,21 +239,25 @@ class BaseEstimator(LineageEstimatorMixin, Partitioner, ABC):
         **kwargs,
     ) -> None:
         """
-        Set the approximate recurrent classes, if they are known a priori.
+        Manually define terminal states.
 
         Parameters
         ----------
         labels
-            Either a categorical :class:`pandas.Series` with index as cell names, where `NaN` marks marks a cell
-            belonging to a transient state or a :class:`dict`, where each key is the name of the recurrent class and
-            values are list of cell names.
+            Defines the terminal states. Can be either one of
+            - a categorical :class:`pandas.Series` where each category corresponds to one terminal state. `NaN` entries
+                denote cells that do not belong to any terminal state, i.e. these are either initial or transient cells.
+            - a :class:`dict` of the form `{'terminal_state_a': ['cell_1', 'cell_2', ...]}`, i.e. keys are terminal
+                states, values are lists of cell barcodes corresponding to annotations in :attr:`adata.obs_names`.
         cluster_key
-            If a key to cluster labels is given, :attr:`{fs}` will be associated with these for naming and colors.
+            Key from :attr:`adata.obs` where categorical cluster labels are stored. These are used to associate names
+            and colors with each terminal state. Each terminal state will be given the name and color corresponding to
+            the cluster it mostly overlaps with.
         %(en_cutoff_p_thresh)s
         add_to_existing
-            Whether to add these categories to existing ones. Cells already belonging to recurrent classes will be
-            updated if there's an overlap.
-            Throws an error if previous approximate recurrent classes have not been calculated.
+            Whether the new terminal states should be added to pre-existing ones. Cells already assigned to a terminal
+            state will be re-assigned to the new terminal state if there's a conflict between old and new annotations.
+            This throws an error if no previous annotations corresponding to terminal states have been found.
 
         Returns
         -------

--- a/cellrank/tl/estimators/_base_estimator.py
+++ b/cellrank/tl/estimators/_base_estimator.py
@@ -247,8 +247,8 @@ class BaseEstimator(LineageEstimatorMixin, Partitioner, ABC):
             Defines the terminal states. Can be either one of
             - a categorical :class:`pandas.Series` where each category corresponds to one terminal state. `NaN` entries
                 denote cells that do not belong to any terminal state, i.e. these are either initial or transient cells.
-            - a :class:`dict` of the form `{'terminal_state_a': ['cell_1', 'cell_2', ...]}`, i.e. keys are terminal
-                states, values are lists of cell barcodes corresponding to annotations in :attr:`adata.obs_names`.
+            - a :class:`dict` where keys are terminal states and values are lists of cell barcodes corresponding to
+                annotations in :attr:`adata.obs_names`.
         cluster_key
             Key from :attr:`adata.obs` where categorical cluster labels are stored. These are used to associate names
             and colors with each terminal state. Each terminal state will be given the name and color corresponding to

--- a/tests/test_gpcca.py
+++ b/tests/test_gpcca.py
@@ -1,6 +1,6 @@
 import os
 from copy import deepcopy
-from typing import Tuple
+from typing import List, Tuple, Union
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -578,6 +578,27 @@ class TestGPCCA:
         mc.compute_macrostates(n_states=2)
         with pytest.raises(KeyError):
             mc.set_terminal_states_from_macrostates(names=["foobar"])
+
+    @pytest.mark.parametrize("values", ["Astrocytes", ["Astrocytes", "OPC"]])
+    def test_set_terminal_states_clusters(
+        self, adata_large: AnnData, values: Union[str, List[str]]
+    ):
+        vk = VelocityKernel(adata_large).compute_transition_matrix(softmax_scale=4)
+        ck = ConnectivityKernel(adata_large).compute_transition_matrix()
+        terminal_kernel = 0.8 * vk + 0.2 * ck
+
+        to_remove = list(
+            set(adata_large.obs["clusters"].cat.categories)
+            - ({values} if isinstance(values, str) else set(values))
+        )
+        expected = adata_large.obs["clusters"].cat.remove_categories(to_remove)
+
+        mc = cr.tl.estimators.GPCCA(terminal_kernel)
+
+        mc.set_terminal_states({"clusters": values})
+        pd.testing.assert_series_equal(
+            expected, mc.terminal_states, check_category_order=False, check_names=False
+        )
 
     def test_compute_terminal_states_invalid_method(self, adata_large: AnnData):
         vk = VelocityKernel(adata_large).compute_transition_matrix(softmax_scale=4)


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull request](../pulls) before creating one.**

## Title
Update the docstring for `estimator.set_terminal_states`. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Was outdated. @michalk8, if possible, could you please add the following two functionalities (additionally to what we currently have):
- allow dict's of the form `{'cluster_key_from_obs': ['cluster_1', 'cluster_2', ...]}, i.e. directly use a subset of pre-defined clusters to define terminal states
- if real-time annotations are present, add a mechanism such that terminal states can be restricted to come from a certain time-point (optionally). 

If the second point is too difficult, don't worry, then we don't do it. 

## How has this been tested?
<!--- Describe in detail how you've tested your changes. -->

## Closes
<!--- Type `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #606 