### PR TITLE
Check value of frac_to_keep is admissible

### DIFF
--- a/cellrank/tl/kernels/_pseudotime_kernel.py
+++ b/cellrank/tl/kernels/_pseudotime_kernel.py
@@ -105,9 +105,10 @@ class PseudotimeKernel(Kernel):
         Parameters
         ----------
         frac_to_keep
-            The `fract_to_keep` * n_neighbors closest neighbors (according to graph connectivities) are kept, no matter
+            The `frac_to_keep` * n_neighbors closest neighbors (according to graph connectivities) are kept, no matter
             whether they lie in the pseudotemporal past or future. This is done to ensure that the graph remains
-            connected. Only used when `threshold_scheme='hard'`.
+            connected. Only used when `threshold_scheme='hard'`. `frac_to_keep` needs to fall within the
+            interval `[0, 1]`.
         %(soft_scheme_kernel)s
         check_irreducibility
             Optional check for irreducibility of the final transition matrix.

--- a/cellrank/tl/kernels/_pseudotime_schemes.py
+++ b/cellrank/tl/kernels/_pseudotime_schemes.py
@@ -157,8 +157,9 @@ class HardThresholdScheme(ThresholdSchemeABC):
         n_neighs
             Number of neighbors to keep.
         frac_to_keep
-            The `fract_to_keep` * n_neighbors closest neighbors (according to graph connectivities) are kept, no matter
-            whether they lie in the pseudotemporal past or future.
+            The `frac_to_keep` * n_neighbors closest neighbors (according to graph connectivities) are kept, no matter
+            whether they lie in the pseudotemporal past or future. `frac_to_keep` needs to fall within the
+            interval `[0, 1]`.
 
         Returns
         -------

--- a/cellrank/tl/kernels/_pseudotime_schemes.py
+++ b/cellrank/tl/kernels/_pseudotime_schemes.py
@@ -164,6 +164,11 @@ class HardThresholdScheme(ThresholdSchemeABC):
         -------
         %(pt_scheme.returns)s
         """
+        if not (0 <= frac_to_keep <= 1):
+            raise ValueError(
+                f"Expected `frac_to_keep` to be in `[0, 1]`, found `{frac_to_keep}`."
+            )
+
         k_thresh = max(0, min(30, int(np.floor(n_neighs * frac_to_keep))))
         ixs = np.flip(np.argsort(neigh_conn))
         close_ixs, far_ixs = ixs[:k_thresh], ixs[k_thresh:]


### PR DESCRIPTION
The value for `frac_to_keep` should fall in the interval `[0, 1]`. If
this is not the case, an error is thrown and the function exited.

**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Title
<!-- Provide a general summary of your changes in the Title above -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!-- Clearly and concisely describe your changes. -->

Checks that `frac_to_keep` lies within `[0, 1]`.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->

## Have release notes been modified?
<!-- Indicate whether release notes have been (or should) be modifies. -->

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->

Closes #659.
