### PR TITLE
Deprecate NumPy data types

### DIFF
--- a/cellrank/pl/_cluster_fates.py
+++ b/cellrank/pl/_cluster_fates.py
@@ -481,11 +481,11 @@ def cluster_fates(
     d = odict()
     for name in clusters:
         mask = (
-            np.ones((adata.n_obs,), dtype=np.bool)
+            np.ones((adata.n_obs,), dtype=bool)
             if is_all
             else (adata.obs[cluster_key] == name).values
         )
-        mask = np.array(mask, dtype=np.bool)
+        mask = np.array(mask, dtype=bool)
         data = adata.obsm[lk][mask, lin_names].X
         mean = np.nanmean(data, axis=0)
         std = np.nanstd(data, axis=0) / np.sqrt(data.shape[0])

--- a/cellrank/tl/_colors.py
+++ b/cellrank/tl/_colors.py
@@ -155,7 +155,7 @@ def _get_bg_fg_colors(color, sat_scale: Optional[float] = None) -> Tuple[str, st
 
     return (
         mcolors.to_hex(color),
-        _contrasting_color(*np.array(color * 255).astype(np.int)),
+        _contrasting_color(*np.array(color * 255).astype(int)),
     )
 
 

--- a/cellrank/tl/_lineage.py
+++ b/cellrank/tl/_lineage.py
@@ -420,8 +420,8 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
             item_0 = _at_least_2d(item_0, -1)
             item_1 = _at_least_2d(item_1, 0)
 
-            if item_1.dtype == np.bool:
-                if item_0.dtype != np.bool:
+            if item_1.dtype == bool:
+                if item_0.dtype != bool:
                     if not issubclass(item_0.dtype.type, np.integer):
                         raise TypeError(f"Invalid type `{item_0.dtype.type}`.")
                     row_order = (
@@ -433,8 +433,8 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
                 item = item_0 * item_1
                 shape = np.max(np.sum(item, axis=0)), np.max(np.sum(item, axis=1))
                 col = np.where(np.all(item_1, axis=0))[0]
-            elif item_0.dtype == np.bool:
-                if item_1.dtype != np.bool:
+            elif item_0.dtype == bool:
+                if item_1.dtype != bool:
                     if not issubclass(item_1.dtype.type, np.integer):
                         raise TypeError(f"Invalid type `{item_1.dtype.type}`.")
                     col_order = (

--- a/cellrank/tl/_lineage.py
+++ b/cellrank/tl/_lineage.py
@@ -605,7 +605,7 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
 
     @property
     def _fmt(self) -> Callable:
-        if np.issubdtype(self.dtype, np.float):
+        if np.issubdtype(self.dtype, float):
             return "{:.06f}".format
         return "{}".format
 

--- a/cellrank/tl/_utils.py
+++ b/cellrank/tl/_utils.py
@@ -1117,7 +1117,7 @@ def _one_hot(n, cat: Optional[int] = None) -> np.ndarray:
     If cat is `None`, return a vector of zeros.
     """
 
-    out = np.zeros(n, dtype=np.bool)
+    out = np.zeros(n, dtype=bool)
     if cat is not None:
         out[cat] = True
 
@@ -1207,7 +1207,7 @@ def _fuzzy_to_discrete(
 
     # create the one-hot encoded discrete clustering
     a_discrete = np.zeros(
-        a_fuzzy.shape, dtype=np.bool
+        a_fuzzy.shape, dtype=bool
     )  # don't use `zeros_like` - it also copies the dtype
     for ix in range(n_clusters):
         a_discrete[sample_assignment[ix], ix] = True
@@ -1270,7 +1270,7 @@ def _series_from_one_hot_matrix(
     membership = np.asarray(
         membership
     )  # change the type in case a lineage object was passed.
-    if membership.dtype != np.bool:
+    if membership.dtype != bool:
         raise TypeError(
             f"Expected `membership`'s elements to be boolean, found `{membership.dtype.name!r}`."
         )

--- a/cellrank/ul/models/_base_model.py
+++ b/cellrank/ul/models/_base_model.py
@@ -537,9 +537,7 @@ class BaseModel(Pickleable, ABC, metaclass=BaseModelMeta):
 
         if filter_cells is not None:
             tmp = y.squeeze()
-            fil = (tmp >= filter_cells) & (
-                ~np.isclose(tmp, filter_cells).astype(np.bool)
-            )
+            fil = (tmp >= filter_cells) & (~np.isclose(tmp, filter_cells).astype(bool))
             x, y, w = x[fil], y[fil], w[fil]
             self._obs_names = self._obs_names[fil]
 

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -346,7 +346,7 @@ class TestLineageAccessor:
             colors=[(0, 0, 0), (0.5, 0.5, 0.5), (1, 1, 1)],
         )
 
-        mask = np.ones((x.shape[0]), dtype=np.bool)
+        mask = np.ones((x.shape[0]), dtype=bool)
         mask[:5] = False
         y = l[mask, :]
 
@@ -372,7 +372,7 @@ class TestLineageAccessor:
             colors=[(0, 0, 0), (0.5, 0.5, 0.5), (1, 1, 1)],
         )
 
-        mask = np.ones((x.shape[1]), dtype=np.bool)
+        mask = np.ones((x.shape[1]), dtype=bool)
         mask[0] = False
         y = l[:, mask]
 
@@ -410,7 +410,7 @@ class TestLineageAccessor:
             colors=[(0, 0, 0), (0.5, 0.5, 0.5), (1, 1, 1)],
         )
 
-        mask = np.ones((x.shape[1]), dtype=np.bool)
+        mask = np.ones((x.shape[1]), dtype=bool)
         mask[0] = False
         y = l[[0, 1], mask]
 
@@ -436,7 +436,7 @@ class TestLineageAccessor:
             colors=[(0, 0, 0), (0.5, 0.5, 0.5), (1, 1, 1)],
         )
 
-        mask = np.ones((x.shape[0]), dtype=np.bool)
+        mask = np.ones((x.shape[0]), dtype=bool)
         mask[5:] = False
         y = l[mask, 0]
 
@@ -450,9 +450,9 @@ class TestLineageAccessor:
             colors=[(0, 0, 0), (0.5, 0.5, 0.5), (1, 1, 1)],
         )
 
-        row_mask = np.ones((x.shape[0]), dtype=np.bool)
+        row_mask = np.ones((x.shape[0]), dtype=bool)
         row_mask[5:] = False
-        col_mask = np.ones((x.shape[1]), dtype=np.bool)
+        col_mask = np.ones((x.shape[1]), dtype=bool)
         y = l[row_mask, col_mask]
 
         np.testing.assert_array_equal(x[row_mask, :][:, col_mask], np.array(y))
@@ -465,7 +465,7 @@ class TestLineageAccessor:
             colors=[(0, 0, 0), (0.5, 0.5, 0.5), (1, 1, 1)],
         )
 
-        mask = np.ones((x.shape[0]), dtype=np.bool)
+        mask = np.ones((x.shape[0]), dtype=bool)
         mask[5:] = False
         y = l[mask, ["baz", "bar"]]
 
@@ -488,7 +488,7 @@ class TestLineageAccessor:
             x, names=["foo", "bar", "baz"], colors=["#ff0000", "#00ff00", "#0000ff"]
         )
 
-        mask = np.ones((x.shape[0]), dtype=np.bool)
+        mask = np.ones((x.shape[0]), dtype=bool)
         mask[5:] = False
         y = l[mask, :][:, ["baz", "bar", "foo"]]
 
@@ -502,7 +502,7 @@ class TestLineageAccessor:
             x, names=["foo", "bar", "baz"], colors=["#ff0000", "#00ff00", "#0000ff"]
         )
 
-        mask = np.ones((x.shape[0]), dtype=np.bool)
+        mask = np.ones((x.shape[0]), dtype=bool)
         mask[5:] = False
         y = l[mask, ["baz", "bar", "foo"]]
         z = l[mask, :][:, ["baz", "bar", "foo"]]
@@ -552,7 +552,7 @@ class TestLineageAccessor:
         x = np.random.random((10, 3))
         l = Lineage(x, names=["Beta", "Epsilon", "Alpha"])
         cmapper = dict(zip(l.names, l.colors))
-        mask = np.zeros(l.shape[0], dtype=np.bool)
+        mask = np.zeros(l.shape[0], dtype=bool)
         mask[0] = True
         mask[-1] = True
 
@@ -935,7 +935,7 @@ class TestTransposition:
         np.testing.assert_array_equal(x, y.T[:, ::-1])
 
     def test_boolean_accessor(self, lineage: Lineage):
-        mask = np.zeros(shape=lineage.shape[0], dtype=np.bool)
+        mask = np.zeros(shape=lineage.shape[0], dtype=bool)
         mask[[3, 5]] = True
 
         y = lineage.T[["baz", "bar"], mask]


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Deprecate NumPy data types
<!-- Provide a general summary of your changes in the Title above -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

## Description

Deprecates NumPy data types in favor of builtin ones, e.g. `np.bool` by `bool`.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->

N/A

## Have release notes been modified?
<!-- Indicate whether release notes have been (or should) be modifies. -->

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->

Closes #717.
