### PR TITLE
Restrict embedding projection to knn based kernels

### DIFF
--- a/cellrank/tl/kernels/_base_kernel.py
+++ b/cellrank/tl/kernels/_base_kernel.py
@@ -298,18 +298,18 @@ class KernelExpression(Pickleable, ABC):
                 "Compute transition matrix first as `.compute_transition_matrix()`."
             )
 
-        kernels_w_conn = [kernel for kernel in self.kernels if kernel._conn is not None]
-        if not len(kernels_w_conn):
-            raise AttributeError(
-                "Connectivity matrix not defined. As of now, the embedding projection "
-                "only works for kNN based kernels."
-            )
+        for kernel in self.kernels:
+            if kernel._conn is None:
+                raise AttributeError(
+                    f"{kernel!r} is not a kNN based kernel. The embedding projection "
+                    "only works for kNN based kernels."
+                )
 
         start = logg.info(f"Projecting transition matrix onto `{basis}`")
         emb = _get_basis(self.adata, basis)
         T_emb = np.empty_like(emb)
 
-        conn = kernels_w_conn[0]._conn
+        conn = self.kernels[0]._conn
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -75,6 +75,35 @@ class TestOTKernel:
         np.testing.assert_allclose(ok.transition_matrix.sum(1), 1.0)
         assert isinstance(ok.params, dict)
 
+    @pytest.mark.parametrize("connectivity_kernel", (None, ConnectivityKernel))
+    def test_compute_projection(
+        self, adata_large: AnnData, connectivity_kernel: Optional[ConnectivityKernel]
+    ):
+        terminal_states = np.full((adata_large.n_obs,), fill_value=np.nan, dtype=object)
+        ixs = np.where(adata_large.obs["clusters"] == "Granule immature")[0]
+        terminal_states[ixs] = "GI"
+
+        ok = cre.kernels.StationaryOTKernel(
+            adata_large,
+            terminal_states=pd.Series(terminal_states).astype("category"),
+            g=np.ones((adata_large.n_obs,), dtype=np.float64),
+        )
+        ok = ok.compute_transition_matrix(1, 0.001)
+
+        if connectivity_kernel is not None:
+            ck = connectivity_kernel(adata_large).compute_transition_matrix()
+            combined_kernel = 0.9 * ok + 0.1 * ck
+            combined_kernel.compute_transition_matrix()
+        else:
+            combined_kernel = ok
+
+        expected_error = (
+            r"<StationaryOTKernel> is not a kNN based kernel. The embedding projection "
+            r"only works for kNN based kernels."
+        )
+        with pytest.raises(AttributeError, match=expected_error):
+            combined_kernel.compute_projection()
+
 
 class TestWOTKernel:
     def test_no_connectivities(self, adata_large: AnnData):
@@ -256,6 +285,27 @@ class TestWOTKernel:
         assert isinstance(ok2, cre.kernels.WOTKernel)
         assert ok is not ok2
         np.testing.assert_array_equal(ok.transition_matrix.A, ok2.transition_matrix.A)
+
+    @pytest.mark.parametrize("connectivity_kernel", (None, ConnectivityKernel))
+    def test_compute_projection(
+        self, adata_large: AnnData, connectivity_kernel: Optional[ConnectivityKernel]
+    ):
+        ok = cre.kernels.WOTKernel(adata_large, time_key="age(days)")
+        ok = ok.compute_transition_matrix()
+
+        if connectivity_kernel is not None:
+            ck = connectivity_kernel(adata_large).compute_transition_matrix()
+            combined_kernel = 0.9 * ok + 0.1 * ck
+            combined_kernel.compute_transition_matrix()
+        else:
+            combined_kernel = ok
+
+        expected_error = (
+            r"<WOTKernel> is not a kNN based kernel. The embedding projection only "
+            r"works for kNN based kernels."
+        )
+        with pytest.raises(AttributeError, match=expected_error):
+            combined_kernel.compute_projection()
 
 
 class TestGetMarkers:


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Title
<!-- Provide a general summary of your changes in the Title above -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!-- Clearly and concisely describe your changes. -->

Restricts computation of embedding projection to kNN based kernels.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->

`TestOTKernel` and `TestWOTKernel` are extended by one unit test each to verify that expected error is thrown.

## Have release notes been modified?
<!-- Indicate whether release notes have been (or should) be modifies. -->

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->

Closes #668.
