### PR TITLE
Fix WOT unused kwargs

### DIFF
--- a/cellrank/external/kernels/_wot_kernel.py
+++ b/cellrank/external/kernels/_wot_kernel.py
@@ -342,6 +342,7 @@ class WOTKernel(Kernel, error=_error):
         _ = kwargs.pop("covariate_field", None)
         _ = kwargs.pop("ncounts", None)
         _ = kwargs.pop("ncells", None)
+        _ = kwargs.pop("parameters", None)  # parameters file
         kwargs["lambda1"] = lambda1
         kwargs["lambda2"] = lambda2
         kwargs["epsilon"] = epsilon
@@ -399,8 +400,18 @@ class WOTKernel(Kernel, error=_error):
         ] = None,
         solver: Literal["fixed_iters", "duality_gap"] = "duality_gap",
         growth_rate_field: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Dict[Tuple[float, float], AnnData]:
+        _ = wot.ot.OTModel(
+            adata,
+            day_field=self._time_key,
+            covariate_field=None,
+            growth_rate_field=growth_rate_field,
+        )
+        for k in kwargs:
+            if k not in _.ot_config:
+                raise TypeError(f"WOT got an unexpected keyword argument {k!r}.")
+
         self._ot_model = wot.ot.OTModel(
             adata,
             day_field=self._time_key,

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -115,6 +115,11 @@ class TestWOTKernel:
         assert ok._conn is None
         np.testing.assert_allclose(ok.transition_matrix.sum(1), 1.0)
 
+    def test_invalid_solver_kwargs(self, adata_large: AnnData):
+        ok = cre.kernels.WOTKernel(adata_large, time_key="age(days)")
+        with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
+            ok.compute_transition_matrix(foo="bar")
+
     def test_inversion_updates_adata(self, adata_large: AnnData):
         key = "age(days)"
         ok = cre.kernels.WOTKernel(adata_large, time_key=key)


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Title
<!-- Provide a general summary of your changes in the Title above -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!-- Clearly and concisely describe your changes. -->

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
Fix :func:`cellrank.external.kernels.WOTKernel.compute_transition_matrix` silently ignoring unexpected kwargs.

## Have release notes been modified?
<!-- Indicate whether release notes have been (or should) be modifies. -->

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
closes #721 