### PR TITLE
Fix exp. time kernel colors

### DIFF
--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -47,12 +47,12 @@ jobs:
                 skip_dirty_check: false
 
         -   name: Update dev release notes
-            if: ${{ steps.auto-commit-action.outputs.changes_detected == 'true' && contains(github.base_ref, 'dev') }}
+            if: ${{ contains(github.base_ref, 'dev') }}
             run: |
                 tox -e update-dev-notes
 
         -   name: Commit dev release notes
-            if: ${{ steps.auto-commit-action.outputs.changes_detected == 'true' && contains(github.base_ref, 'dev') }}
+            if: ${{ contains(github.base_ref, 'dev') }}
             uses: stefanzweifel/git-auto-commit-action@v4
             with:
                 commit_message: ${{ format('[auto][ci skip] Update dev release notes (#{0})', github.event.number) }}

--- a/cellrank/tl/kernels/_exp_time_kernel.py
+++ b/cellrank/tl/kernels/_exp_time_kernel.py
@@ -68,7 +68,7 @@ class ExperimentalTimeKernel(Kernel, ABC):
         cmap = get_cmap(kwargs.pop("cmap", "gnuplot"))
         cats = self.experimental_time.cat.categories
         norm = Normalize(vmin=cats.min(), vmax=cats.max())
-        self.adata.uns[f"{time_key}_colors"] = np.array([to_hex(c) for c in cmap(norm(cats) * cmap.N)])
+        self.adata.uns[f"{time_key}_colors"] = np.array([to_hex(c) for c in cmap(norm(cats))])
         # fmt: on
 
     @d.dedent

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -14,6 +14,7 @@ import pandas as pd
 from scipy.sparse import csr_matrix
 from pandas.core.dtypes.common import is_categorical_dtype
 
+import matplotlib.pyplot as plt
 from matplotlib.cm import get_cmap
 from matplotlib.colors import to_hex
 
@@ -352,6 +353,23 @@ class TestWOTKernel:
             sorted(ok.transport_maps.keys()), sorted(ok2.transport_maps.keys())
         )
         np.testing.assert_array_equal(ok.transition_matrix.A, ok2.transition_matrix.A)
+
+    @pytest.mark.parametrize("cmap", ["viridis", "inferno"])
+    @pytest.mark.parametrize("size", [5, 10])
+    def test_colormap(self, adata_large: AnnData, cmap: str, size: int):
+        dummy_time = pd.cut(adata_large.obs["latent_time"], size).cat.rename_categories(
+            range(13, 13 + size)
+        )
+        adata_large.obs["dummy_time"] = dummy_time
+        expected_colors = [
+            to_hex(c) for c in plt.get_cmap(cmap)(np.linspace(0.0, 1.0, size))
+        ]
+
+        _ = cre.kernels.WOTKernel(adata_large, time_key="dummy_time", cmap=cmap)
+
+        np.testing.assert_array_equal(
+            adata_large.uns["dummy_time_colors"], expected_colors
+        )
 
 
 class TestGetMarkers:


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Fix color creating in :class:`cellrank.tl.kernels.ExperimentalTimeKernel`.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
1 new test.

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
closes #782 