### PR TITLE
Fix/correlation qval nan

### DIFF
--- a/cellrank/tl/_utils.py
+++ b/cellrank/tl/_utils.py
@@ -417,9 +417,17 @@ def _correlation_test(
         confidence_level=confidence_level,
         **kwargs,
     )
-    invalid = np.sum((corr < -1) | (corr > 1))
-    if invalid:
-        raise ValueError(f"Found `{invalid}` correlations that are not in `[0, 1]`.")
+    invalid = (corr < -1) | (corr > 1)
+    if np.any(invalid):
+        logg.warning(
+            f"Found `{np.sum(invalid)}` correlation(s) that are not in `[0, 1]`. "
+            f"This usually happens when gene expression is constant across all cells. "
+            f"Setting to `NaN`"
+        )
+        corr[invalid] = np.nan
+        pvals[invalid] = np.nan
+        ci_low[invalid] = np.nan
+        ci_high[invalid] = np.nan
 
     res = pd.DataFrame(corr, index=gene_names, columns=[f"{c}_corr" for c in Y.names])
     for idx, c in enumerate(Y.names):

--- a/cellrank/tl/_utils.py
+++ b/cellrank/tl/_utils.py
@@ -423,8 +423,15 @@ def _correlation_test(
 
     res = pd.DataFrame(corr, index=gene_names, columns=[f"{c}_corr" for c in Y.names])
     for idx, c in enumerate(Y.names):
-        res[f"{c}_pval"] = pvals[:, idx]
-        res[f"{c}_qval"] = multipletests(pvals[:, idx], alpha=0.05, method="fdr_bh")[1]
+        p = pvals[:, idx]
+        valid_mask = ~np.isnan(p)
+
+        res[f"{c}_pval"] = p
+        res[f"{c}_qval"] = np.nan
+        if np.any(valid_mask):
+            res.loc[gene_names[valid_mask], f"{c}_qval"] = multipletests(
+                p[valid_mask], alpha=0.05, method="fdr_bh"
+            )[1]
         res[f"{c}_ci_low"] = ci_low[:, idx]
         res[f"{c}_ci_high"] = ci_high[:, idx]
 

--- a/tests/test_gpcca.py
+++ b/tests/test_gpcca.py
@@ -1087,6 +1087,21 @@ class TestGPCCA:
         _assert_params(g, state, fwd=False)
         _assert_params(g, state, fwd=True)
 
+    def test_drivers_constant_gene_qvalues(self, adata_large: AnnData):
+        ix = 0
+        gene = adata_large.var_names[ix]
+        adata_large.X[:, ix] = 0
+        ck = ConnectivityKernel(adata_large).compute_transition_matrix()
+        g = cr.tl.estimators.GPCCA(ck)
+        g.fit(n_states=2)
+        g.predict()
+        g.compute_absorption_probabilities()
+
+        drivers = g.compute_lineage_drivers(use_raw=False)
+
+        np.testing.assert_array_equal(drivers.loc[gene], np.nan)
+        assert np.asarray(drivers.iloc[drivers.index != gene].isnull()).sum() == 0
+
 
 class TestGPCCASerialization:
     @pytest.mark.parametrize("state", list(State))


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Fix all q-values being NaN if 1 p-value was NaN. Also warn and set to NaN instead of raise when correlations are not in ``[0, 1]]`` interval.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
1 new test.

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
closes #819