### PR TITLE
Do not save Enums in AnnData

### DIFF
--- a/cellrank/tl/kernels/_velocity_kernel.py
+++ b/cellrank/tl/kernels/_velocity_kernel.py
@@ -132,7 +132,7 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel, ABC):
         start = logg.info(f"Computing transition matrix using `{model!r}` model")
 
         # fmt: off
-        params = {"model": model, "similarity": str(similarity), "softmax_scale": softmax_scale}
+        params = {"model": str(model), "similarity": str(similarity), "softmax_scale": softmax_scale}
         if self.backward:
             params["bwd_mode"] = str(backward_mode)
         if VelocityModel(model) == VelocityModel.MONTE_CARLO:


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Do not save enums in :class:`anndata.AnnData`.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
1 new test.

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
closes #840 