### PR TITLE
Add option to export plot in pl.heatmap

### DIFF
--- a/cellrank/pl/_gene_trend.py
+++ b/cellrank/pl/_gene_trend.py
@@ -331,7 +331,7 @@ def gene_trends(
             ax.remove()
 
     fig.suptitle(suptitle, y=1.05)
-    
+
     if return_figure:
         return fig
 

--- a/cellrank/pl/_gene_trend.py
+++ b/cellrank/pl/_gene_trend.py
@@ -70,6 +70,7 @@ def gene_trends(
     figsize: Optional[Tuple[float, float]] = None,
     dpi: Optional[int] = None,
     save: Optional[Union[str, Path]] = None,
+    return_figure: bool = False,
     plot_kwargs: Mapping[str, Any] = MappingProxyType({}),
     **kwargs: Any,
 ) -> Optional[_return_model_type]:
@@ -146,6 +147,8 @@ def gene_trends(
         Number of columns of the plot when plotting multiple genes. Only used when ``same_plot = True``.
     suptitle
         Suptitle of the figure.
+    return_figure
+        Whether to return the figure object.
     %(return_models)s
     %(parallel)s
     %(plotting)s
@@ -328,6 +331,9 @@ def gene_trends(
             ax.remove()
 
     fig.suptitle(suptitle, y=1.05)
+    
+    if return_figure:
+        return fig
 
     if save is not None:
         save_fig(fig, save)

--- a/cellrank/pl/_heatmap.py
+++ b/cellrank/pl/_heatmap.py
@@ -79,6 +79,7 @@ def heatmap(
     dendrogram: bool = True,
     return_genes: bool = False,
     return_models: bool = False,
+    return_figure: bool = False,
     n_jobs: Optional[int] = 1,
     backend: Backend_t = _DEFAULT_BACKEND,
     show_progress_bar: bool = True,
@@ -144,6 +145,8 @@ def heatmap(
     return_genes
         Whether to return the sorted or clustered genes. Only available when ``mode = {m.LINEAGES!r}``.
     %(return_models)s
+    return_figure
+        Whether to return the figure object. Sets ``return_genes = True``
     %(parallel)s
     %(plotting)s
     kwargs
@@ -155,6 +158,8 @@ def heatmap(
 
     If ``return_genes = True`` and ``mode = {m.LINEAGES!r}``, returns :class:`pandas.DataFrame`
     containing the clustered or sorted genes.
+    
+    If ``return_figure = True``, returns a tuple containing the figure and genes. 
     """
 
     def find_indices(series: pd.Series, values) -> List[int]:
@@ -547,6 +552,9 @@ def heatmap(
     logg.debug(f"Plotting `{mode!r}` heatmap")
     fig, genes = _plot_heatmap(mode)
 
+    if return_figure:
+        return (fig, genes)
+    
     if save is not None and fig is not None:
         if not isinstance(fig, Iterable):
             save_fig(fig, save)

--- a/cellrank/pl/_heatmap.py
+++ b/cellrank/pl/_heatmap.py
@@ -158,8 +158,8 @@ def heatmap(
 
     If ``return_genes = True`` and ``mode = {m.LINEAGES!r}``, returns :class:`pandas.DataFrame`
     containing the clustered or sorted genes.
-    
-    If ``return_figure = True``, returns a tuple containing the figure and genes. 
+
+    If ``return_figure = True``, returns a tuple containing the figure and genes.
     """
 
     def find_indices(series: pd.Series, values) -> List[int]:
@@ -554,7 +554,7 @@ def heatmap(
 
     if return_figure:
         return (fig, genes)
-    
+
     if save is not None and fig is not None:
         if not isinstance(fig, Iterable):
             save_fig(fig, save)


### PR DESCRIPTION
## Description
Add ``return_figure`` option to :func:`cellrank.pl.heatmap` which will return the underlying figure object to be edited directly.

## How has this been tested?
No testing done.

## Closes
closes  #869