### PR TITLE
Feat/realtimekernel transition matrix warning

### DIFF
--- a/cellrank/external/kernels/_wot_kernel.py
+++ b/cellrank/external/kernels/_wot_kernel.py
@@ -338,6 +338,15 @@ class WOTKernel(Kernel, error=_error):
         kwargs["growth_iters"] = max(growth_iters, 1)
         self_transitions = SelfTransitions(self_transitions)
 
+        if (
+            (self_transitions is not None)
+            and (conn_weight is None)
+            or not (0 < conn_weight < 1)
+        ):
+            raise ValueError(
+                "If `self_transitions` is used, `conn_weight` needs to be specified as well."
+            )
+
         start = logg.info(
             "Computing transition matrix using Waddington optimal transport"
         )

--- a/cellrank/tl/kernels/_transport_map_kernel.py
+++ b/cellrank/tl/kernels/_transport_map_kernel.py
@@ -270,10 +270,6 @@ class TransportMapKernel(ExperimentalTimeKernel, ABC):
             verbosity = settings.verbosity
             try:  # ignore overly verbose logging
                 settings.verbosity = 0
-                if conn_weight is None or not (0 < conn_weight < 1):
-                    raise ValueError(
-                        "Please specify `conn_weight` in interval `(0, 1)`."
-                    )
                 for i, ((t1, _), tmap) in enumerate(tmaps.items()):
                     if t1 not in self_transitions:
                         continue


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
Throws an error when calculating the transition matrix with the `RealtimeKernel` with `self_transitions` provided but not `conn_weight` (or incorrectly) before calculating the transport maps.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->

## Closes
Closes #875 
