### PR TITLE
Remove default time from PT and RT kernel

### DIFF
--- a/cellrank/external/kernels/_wot_kernel.py
+++ b/cellrank/external/kernels/_wot_kernel.py
@@ -91,14 +91,14 @@ class WOTKernel(Kernel, error=_error):
     def __init__(
         self,
         adata: AnnData,
+        time_key: str,
         backward: bool = False,
-        time_key: str = "exp_time",
         **kwargs: Any,
     ):
         super().__init__(
             adata,
-            backward=backward,
             time_key=time_key,
+            backward=backward,
             **kwargs,
         )
 

--- a/cellrank/kernels/_experimental_time_kernel.py
+++ b/cellrank/kernels/_experimental_time_kernel.py
@@ -37,8 +37,8 @@ class ExperimentalTimeKernel(BidirectionalKernel, ABC):
     def __init__(
         self,
         adata: AnnData,
+        time_key: str,
         backward: bool = False,
-        time_key: str = "exp_time",
         **kwargs: Any,
     ):
         super().__init__(
@@ -49,7 +49,7 @@ class ExperimentalTimeKernel(BidirectionalKernel, ABC):
         )
 
     def _read_from_adata(
-        self, time_key: str = "exp_time", cmap: str = "gnuplot", **kwargs: Any
+        self, time_key: str, cmap: str = "gnuplot", **kwargs: Any
     ) -> None:
         super()._read_from_adata(**kwargs)
 

--- a/cellrank/kernels/_pseudotime_kernel.py
+++ b/cellrank/kernels/_pseudotime_kernel.py
@@ -49,8 +49,8 @@ class PseudotimeKernel(ConnectivityMixin, BidirectionalKernel):
     def __init__(
         self,
         adata: AnnData,
+        time_key: str,
         backward: bool = False,
-        time_key: str = "dpt_pseudotime",
         **kwargs: Any,
     ):
         super().__init__(
@@ -60,7 +60,7 @@ class PseudotimeKernel(ConnectivityMixin, BidirectionalKernel):
             **kwargs,
         )
 
-    def _read_from_adata(self, time_key: str = "dpt_pseudotime", **kwargs: Any) -> None:
+    def _read_from_adata(self, time_key: str, **kwargs: Any) -> None:
         super()._read_from_adata(**kwargs)
         # fmt: off
         self._time_key = time_key


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Remove default real-time and pseudotime arguments from :class:`cellrank.kernels.ExperimentalTimeKernel` and :class:`cellrank.kernels.PseudotimeKernel`.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
N/A

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
closes #888 