### PR TITLE
Fix/precomputed kernel adata

### DIFF
--- a/cellrank/kernels/_precomputed_kernel.py
+++ b/cellrank/kernels/_precomputed_kernel.py
@@ -40,6 +40,11 @@ class PrecomputedKernel(UnidirectionalKernel):
     backward
         Hint whether this is a forward, backward or a unidirectional kernel. Only used when ``object`` is
         :class:`anndata.AnnData`.
+
+    Notes
+    -----
+    If ``object`` is :class:`anndata.AnnData` and neither ``obsp_key`` nor ``backward`` is specified,
+    default forward and backward are tried and first one is used.
     """
 
     _SENTINEL = object()

--- a/cellrank/kernels/_precomputed_kernel.py
+++ b/cellrank/kernels/_precomputed_kernel.py
@@ -69,7 +69,7 @@ class PrecomputedKernel(UnidirectionalKernel):
             raise TypeError(
                 f"Expected `object` to be either `str`, `bool`, `numpy.ndarray`, "
                 f"`scipy.sparse.spmatrix`, `AnnData` or `KernelExpression`, "
-                f"found `{type(object).__name__}`"
+                f"found `{type(object).__name__}`."
             )
 
     def _from_adata(
@@ -80,16 +80,32 @@ class PrecomputedKernel(UnidirectionalKernel):
         copy: bool = False,
     ) -> None:
         if obsp_key is None:
-            obsp_key = Key.uns.kernel(backward)
+            if backward is PrecomputedKernel._SENTINEL:
+                for backward in [False, True]:  # prefer `forward`
+                    obsp_key = Key.uns.kernel(backward)
+                    if obsp_key in adata.obsp:
+                        break
+                else:
+                    raise ValueError(
+                        "Unable to find transition matrix in `adata.obsp`. "
+                        "Please specify `obsp_key=...` or `backward=...`."
+                    )
+            else:
+                obsp_key = Key.uns.kernel(backward)
+            logg.info(f"Using transition matrix from `adata.obsp[{obsp_key!r}]`")
+
         tmat = _read_graph_data(adata, obsp_key)
+
         if backward is PrecomputedKernel._SENTINEL:
-            # not ideal, since None/False share the same key, we prefer False
+            # not ideal, since None/False share the same key, prefer `forward`
             if obsp_key == Key.uns.kernel(bwd=False):
                 backward = False
             elif obsp_key == Key.uns.kernel(bwd=True):
                 backward = True
             else:
                 backward = None
+            logg.info(f"Setting directionality `backward={backward}`")
+
         self._from_matrix(tmat, adata=adata, backward=backward, copy=copy)
         self.params["origin"] = f"adata.obsp[{obsp_key!r}]"
 

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1475,6 +1475,16 @@ class TestPrecomputedKernel:
 
         np.testing.assert_array_almost_equal(expected, actual.transition_matrix)
 
+    @pytest.mark.parametrize("backward", [False, True])
+    def test_precomputed_autodetection(self, adata: AnnData, backward: bool):
+        key = Key.uns.kernel(backward)
+        adata.obsp[key] = mat = random_transition_matrix(adata.n_obs)
+        pk = PrecomputedKernel(adata)
+
+        assert pk.backward == backward
+        assert key in pk.params["origin"]
+        np.testing.assert_array_equal(mat, pk.transition_matrix)
+
 
 class TestKernelIO:
     @pytest.mark.parametrize("copy", [False, True])


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Fix using sentinel value when using :class:`cellrank.kernels.PrecomputedKernel.` and neither key nor direction was specified.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
1 new parametrized test.

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
cloes #906 