### PR TITLE
[ci skip] Add example thumbnails

### DIFF
--- a/docs/source/Untitled.ipynb
+++ b/docs/source/Untitled.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "337faddc",
+   "metadata": {},
+   "source": [
+    "# Using `nbsphinx-thumbnail` metadata tag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "841f2efb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "35c8a3a1",
+   "metadata": {
+      "tags": [
+       "nbsphinx-thumbnail"
+      ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PathCollection at 0x7fc392a75fa0>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXIAAAD4CAYAAADxeG0DAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAATWklEQVR4nO3df4jd5ZXH8c8ZYwSbUNNmdgWjSWG7QnBd2lxqpCwLVdh0V7a0rIthKZSKYaFlWygUXf9f/yj0n7YgI0r/CZFl29KCFqtSkO4m0jvWddVUkWI0RewYxzZGMU7u2T8yo5Obe2fuvd9fz3me9wsKzp30fp/53u893/Oc58fX3F0AgLjmum4AAKAaAjkABEcgB4DgCOQAEByBHACC29LFQXfu3Ol79uzp4tAAENbi4uIb7j4//HongXzPnj3q9/tdHBoAwjKzE6Nep7QCAMERyAEgOAI5AARHIAeA4AjkABAcgRwAgiOQY2aDgWvp9HtiB02gW53MI0d8g4Hr4H3HtHhiWft279CRO/Zrbs66bhZQpMoZuZldbWa/NLPnzew5M/tGHQ1D2k6dOavFE8taGbgWTyzr1Jmztb4/2T4wuTpKKyuSvuXueyXtl/Q1M9tbw/siYTu3bdW+3Tu0Zc60b/cO7dy2tbb3Xsv2b7zncd22cEyDAcEc2Ejl0oq7vybptdX/Pm1mxyVdJen5qu+NdJmZjtyxX6fOnNXObVtlVl9ZZVS2P7/9sg3/P4OBN9IWIIJaBzvNbI+kT0l6csTvDplZ38z6S0tLdR4WHZmbM81vv6z2wDlttk8GTymqdLUNdprZNkk/kvRNd//T8O/dfUHSgiT1ej2uNow1bbY/SwafEwaeUUtGbmaX6nwQP+zuP67jPfGhErOtabL9STL4nM9h0wPPSF/ljNzOf9Pul3Tc3b9bvUlYj2xrc5tl8Lmfw7Ub2drfV+fAM2Koo7TyWUlflvR/Zvb06mv/7u4P1/DexSu9bDCptQx+lNzPYZMDz4ihjlkrv5LEldMQsq3qSjiHG93IkD/rombY6/WcJwRNjql11XEOkQMzW3T33vDr7LUSQFPT/EpS8jnMeaAX57HXCpCx3Ad6cR4ZOZAxpiaWgUAOZKzJPXGQDkorQMaYmlgGMnJkhYG9i5U80FsKMnJkg4E9lIqMHNlgYA+lIpAjG5sN7FF2Qa4orSAbGw3spVB2aWN1KStYy0QgL0QpX/Bxe450vXFWGzeSFG5W6AallQLwBJ3u51O3Ub9njKBcZOQF6DobTUHX86nb2IEx910eS+lVzoJAXoDcv+CT6nKr1zZuJF3frJpE2WhjBPLAJs1Qcv6CR9LGjSTXfcnpVW6MGnlQ09a9Wd2HyLoe40gdGXlQZCgoCb3KjZGRB0WGgtLQqxyPjDwoMhQAawjkgeU6sAVgOpRWACA4AjkABEcgB4DgCOQAEByBHACCI5ADQHAEcgAIjkAOAMERyAEgOAI5UBEPdUbXWKIPVMADD5ACMnKggkmek0nGjqYRyAtEYKnPZtsJ8+BrtIHSSmEoBdRrs+2EeQAI2kBGXphJSgElqaN3stEDD3gACNpARl6YtcCylpGXHFja6J3wABC0oZZAbmYPSLpF0h/c/bo63hPNILB8qK2yBw8AQdPqKq38UNKBmt4LDcvt2YezlkcoeyAXtWTk7v6Eme2p472AaVQpj9A7mc1g4JyzxLQ22Glmh8ysb2b9paWltg6LzFUdvM2td9I0plOmqbVA7u4L7t5z9978/Hxbh0Vgk5RMKI+0i1lPaWLWCpI0acmE8ki7mPWUJgJ5xtquZdZ5vGlmlDArpD3cONNUS2nFzI5IOirpWjM7aWa31/G+mF3btcy6j0fJJF2MK6SnrlkrB+t4H9Sn7aXhdR+PzA+YXDFL9EvbKKrtjLaJ45H5AZOxLgJbr9fzfr/f2vFK3Sgqco08dSX9rUiHmS26e2/49SIGO0vdga7tQcBSBh1LTQyQriJKKwycoU7MpUZqisjIGThDnZhLjdQUEcilcrr9aB6JAVJTTCAH6kRigJQUUSMHgJwRyAEgOAI5AARHIEdyUl+Fm3r7UB4GO5GU1BfbpN4+lImMHElJfbFN6u1DmT0mAjmSkvoq3NTbN6tcgl+pj6KjtIKkpL7YJvX2zSKnclGx+yp13QBgWOrb107avihZbk7lolx7TJshIwcaECnLzWnvmBx7TJMgkKMobe0jHqmLv1nwi7b3eonbJ1BaSUSUbnhkbQ6ERevijysXlTp4GA0ZeQIidcOnkVom12aWnEsXP1LPomRk5AnIabBpTYqZXNtZcuqDtpOI1rMoFRl5AnIabFqTYiaXS5bcJs5ZDATyBOT4ZUn15lTiQFhVnLP0EcgTkduXJdWbU2p1e6AO1MhrMGrGCbNQ0qsRp1i3B+pARl7RqBknkrKchRJdinV7oA5k5BWNCg45zkLJATMwkCsy8orGDeqlONBXulTr9kBV1kUNt9freb/fb/24TRk1gMagWhr4HJATM1t0997w62TkNRg14yS3WSipG3czZawCJSCQI7zhgH349hu0/O77cvexg5tk6sgJgRzhrR9c7p9Y1j8vHNUzJ/+oT19zhT59zQ499cqFYxVk6sgNgRzhrR9w/qtdH9X/vvqWzrn01Ctv6b/v/JzmzC7IvJmGiNwQyBHe+tkoH//IpTp435MfZNt/NmJBUqrbBwCzYtYKsjNJ/ZsaOSJi1gqKMcmMIWYVISe1rOw0swNm9oKZvWRmd9bxngCAyVQO5GZ2iaQfSPq8pL2SDprZ3qrvC6SCDdCQujpKK5+R9JK7/06SzOxBSV+Q9HwN7w10iqmKiKCO0spVkl5d9/PJ1dcuYGaHzKxvZv2lpaUaDoscpJ7tsgEaImht90N3X3D3nrv35ufn2zosEjAuWEfYH7zKjomp36SQjzpKK7+XdPW6n3etvtY5pph1b6PSRNWFOW18vrPumFh6SYbvXrvqyMh/LemTZvYJM9sq6TZJP6vhfS8yTYYTIdsrwUaliSrZ7srKQP907/9o/3881vjnO8uTjkouyfDda1/ljNzdV8zs65IekXSJpAfc/bnKLRsybYbDMuw0bLSKskq2e+vCUf3mlbckSf2X30zu8y159SjfvfbVsiDI3R+W9HAd7zXOtBdHyV+klGwWrGdZmHPqzFk9c/KPH/z811dfkdznW/JDLPjutS/Mys5pL46Sv0ipqXsV5c5tW9XbvUP9E8u6ftdH9V//emOSn29df3e0ejPfvfaF2msl2gWN5pRyLZQ+aIoLjdtrJdTDl2cZdEKeSrkWSh40zVFTU1JDBXIgd8Nf9Coze5CWJmfzhKmRY3OllBtyNa6MQr05D03O5iEjzwRzd9M1aXd6XBmllDJS7prsXZGRZ4K5u2maZrAy2rQ9eoDTaXI2D4E8E9GCQCmmucFGmraX62yapm9OTT3QhEAeyEYX2SRBIGoGFbXd0vQ32ChPLsqxBxj55kQgD2KSi2yjIBD1Io3a7jWRsuxp5NgDjHxzIpAHUfUii3qRRm33+l5ElCx7GjneoCLfnAjkQUxzkY0qRUS9SCO2O3ovYlK53aAi35xCLdEv3SS14o2CSMq15o3alnK7R1k6/Z5uvOdxrQxcW+ZMR++6KauAl4po10UdsliiX7rh+cSj5idvtKQ71fnIm82BT7Xd47Aas3msm7gQpZWgxmXeEUsRUevg40TuokeR2zVTFYE8qHEXcldBpEo3N+LNZzO51Y9Tk+M1UwWBvEFN1vA2upDbDiJVB/fIYDEtrpkLEcgb0vTMhZQu5Dq6uW3efEocJMsRvZ4PMdjZkDb2kU5lEDDS4B6DZMgRGXlDcqzhjctkU+odbIZBMuSIQN6QSMFtEpuViqJ0c3O8wQIE8gZFCW6TSDGTnaXWPesNlro6UkYgx0RSy2SrDCZPe4MtZck94iKQYyKbZbJtZqyDgevF10+rf2JZ51roIYzrjZClIxUEckxsXCbbZsa6dqz+y2/q8su26J2z5z7oITQVWEf1RsjSkRICOSprs36+dqxzLr3z3ooe+re/0bVXbpe7Gguso3ojb7z9XnJjBigX88hRWZvzyNcfq7fnY7r2yu0ys8bn7a/1RtzP72748Y9cGmbuPPJHRo7K2pxqOe5YbQzGDpdTDt9+g5bffZ8aOTpHIEct2pxqOepYbdxMhrP+5Xffp5yCJFBaQTaa3rIg0lYEKAsZOZIQYSqfmenw7TfopaW39Zd/vi3ZdqI8BHJ0LspUvsHA9S/3P5l8O1EeSivoXBs7RdYhSjtRHgI5Ohel9hylnSiPrX9wb1t6vZ73+/3Wj4s0rT1E2kxJ7K++kQi1fOTLzBbdvTf8OjVydGpUfbzp+FglGOe0oyXyUam0Yma3mtlzZjYws4vuEmjfWnbbRU9rFm3XnXlCEHJUtUb+rKQvSXqihrZghGkCc8Qg1XbdmQFL5KhSacXdj0uiVtiQaaflpfjwh83UtSJz0nJJavuqA3VorUZuZockHZKka665pq3DhjZtYI4apKrWnae54c1y42CAE6nbNJCb2WOSrhzxq7vd/aeTHsjdFyQtSOdnrUzcwoJNG5irZLezBqsUgty0N7xpbhxRFiuhbJsGcne/uY2G4GKzBOZZsttZg1UqQa7JnkjEchXKw/TDxLUx3W3WYJVKkGty58Oo5SqUpVIgN7MvSvqepHlJD5nZ0+7+d7W0DK2ZNVilFOSauuE1cZNIoRyFvLCyE5Ji18gjSaUchZjGrexkrxVImn0v76b3AM/NqHJUtEVcSA+BHGjR8AKoj11+abhFXEgPg50oVhdloeGa+xtvpzFgjNjIyFGkLrczWF+OYmtc1IGMHI1IfRC0hKmTKAcZOWoXYfOulDJhBoxRFRn5kFGZZOrZZWpSyXZHWf9ZkgkjF2Tk64zKJFPMLlOfrlZXtlv33zn8WUrpP5EImAQZ+Trj9qpOKbuMsKCkjrpvE39nyj0FoAoy8nVGZZIp1VKlC4NR/+U39eLrp5PMzKvWfZt4AERqnyVQF5boD0m9Ru7uum3hmPovv6nLL9uid86eUy/RzLyKtb9zLSN/8ND+4vY5abqtkc4Fzhu3RJ9AHtBg4Hrx9dP6h+/9SucGri1zpqN33ZRdmaDkQNN0CS1CiQ4XY6+VjMzNma69crt6mZcJSp6W1/SzRXl2aV4Y7AyKhSR5a3qL4JS2IEZ1lFaARFEjx7BxpRUyciBRTT8dqo2nT6Ed1MgBIDgCOQAERyAHgOAI5AAQHIEcAIIjkANAcARyAAiOQA4AwRHIASA4AjkABEcgB4DgCOQAEByBHACCI5ADQHAEcgAIjkAOAMERyAEgOAI5AARHIAeA4AjkABAcgRwAgqsUyM3sO2b2WzN7xsx+YmZX1NQuAMCEqmbkj0q6zt2vl/SipLuqNylvg4Fr6fR7cveumwIgE5UCubv/wt1XVn88JmlX9SblazBwHbzvmG6853HdtnBMgwHBHEB1ddbIvyrp5+N+aWaHzKxvZv2lpaUaDxvHqTNntXhiWSsD1+KJZZ06c7brJgHIwKaB3MweM7NnR/zvC+v+zd2SViQdHvc+7r7g7j13783Pz9fT+mB2btuqfbt3aMucad/uHdq5bWvXTQKQgS2b/QN3v3mj35vZVyTdIukmp/C7ITPTkTv269SZs9q5bavMrOsmAcjApoF8I2Z2QNK3Jf2tu79TT5PyNjdnmt9+WdfNAJCRqjXy70vaLulRM3vazO6toU0AgClUysjd/S/qaggAYDas7ASA4AjkABAcgRwAgiOQA0BwBHIACI5AjkrYBAzoXqXphyjb2iZgiyeWtW/3Dh25Y7/m5litCrSNjBwzYxMwIA0EcsyMTcCANFBawczYBAxIA4EclbAJGNA9SisAEByBHACCI5ADQHAEcgAIjkAOAMERyAEgOOtijwwzW5J0Yt1LOyW90XpDYuJcTYbzNBnO02RSOU+73X1++MVOAvlFjTDru3uv63ZEwLmaDOdpMpynyaR+niitAEBwBHIACC6VQL7QdQMC4VxNhvM0Gc7TZJI+T0nUyAEAs0slIwcAzIhADgDBJRPIzew7ZvZbM3vGzH5iZld03aYUmdmtZvacmQ3MLNnpUF0xswNm9oKZvWRmd3bdnlSZ2QNm9gcze7brtqTMzK42s1+a2fOr37tvdN2mUZIJ5JIelXSdu18v6UVJd3XcnlQ9K+lLkp7ouiGpMbNLJP1A0ucl7ZV00Mz2dtuqZP1Q0oGuGxHAiqRvufteSfslfS3FayqZQO7uv3D3ldUfj0na1WV7UuXux939ha7bkajPSHrJ3X/n7mclPSjpCx23KUnu/oSkN7tuR+rc/TV3f2r1v09LOi7pqm5bdbFkAvmQr0r6edeNQDhXSXp13c8nleCXDjGZ2R5Jn5L0ZMdNuUirj3ozs8ckXTniV3e7+09X/83dOt+dOdxm21IyyXkC0B4z2ybpR5K+6e5/6ro9w1oN5O5+80a/N7OvSLpF0k1e8AT3zc4Txvq9pKvX/bxr9TVgZmZ2qc4H8cPu/uOu2zNKMqUVMzsg6duS/tHd3+m6PQjp15I+aWafMLOtkm6T9LOO24TAzMwk3S/puLt/t+v2jJNMIJf0fUnbJT1qZk+b2b1dNyhFZvZFMzsp6UZJD5nZI123KRWrg+Vfl/SIzg9K/ae7P9dtq9JkZkckHZV0rZmdNLPbu25Toj4r6cuSPrcal542s7/vulHDWKIPAMGllJEDAGZAIAeA4AjkABAcgRwAgiOQA0BwBHIACI5ADgDB/T8rCqEN43fX4AAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.scatter(np.random.normal(size=(100,)), np.random.normal(size=(100,)), s=5)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "cellrank",
+   "language": "python",
+   "name": "cellrank"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -189,3 +189,7 @@ nbsphinx_prolog = r"""
 """.format(
     version=version, docname="{{ docname|e }}"
 )
+nbsphinx_thumbnails = {
+    "notebooks/tutorials/cellrank_basics": "_static/img/logo.png",
+    "notebooks/tutorials/beyond_rna_velocity": "_images/notebooks_tutorials_beyond_rna_velocity_19_0.png",
+}

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -4,9 +4,10 @@ Under construction.
 
 .. nbgallery::
 
-   notebooks/tutorials/cellrank_basics
-   notebooks/tutorials/cellrank_meets_pseudotime
-   notebooks/tutorials/kernels_and_estimators
-   notebooks/tutorials/beyond_rna_velocity
-   notebooks/tutorials/real_time
-   notebooks/tutorials/creating_new_kernel
+    Untitled
+    notebooks/tutorials/cellrank_basics
+    notebooks/tutorials/cellrank_meets_pseudotime
+    notebooks/tutorials/kernels_and_estimators
+    notebooks/tutorials/beyond_rna_velocity
+    notebooks/tutorials/real_time
+    notebooks/tutorials/creating_new_kernel


### PR DESCRIPTION
This is the example @Marius1311 requested, see also here: https://nbsphinx.readthedocs.io/en/rtd-theme/subdir/gallery.html
I'd prefer to use the path in `_images`, since it is more robust than modifying the code cell's metadata and it doesn't create extra files if we were to manually place them in `_static/img`.

If you agree, please remove the last commit introducing the temporary `Untitled.ipynb` that was just for showcase and update `nbsphinx_thumbnails` accordingly.

closes #903