### PR TITLE
Fix start/end indices size in random walks

### DIFF
--- a/cellrank/kernels/utils/_random_walk.py
+++ b/cellrank/kernels/utils/_random_walk.py
@@ -283,7 +283,7 @@ class RandomWalk:
                 y=emb[ixs][:, 1],
                 outline_color=("black", to_hex(cmap(float(abs(ix))))),
                 kwargs={
-                    "s": kwargs.get("s", default_size(self._adata)) * 1.1,
+                    "s": kwargs.get("size", default_size(self._adata)) * 1.1,
                     "alpha": 0.9,
                 },
                 ax=ax,


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Fix initial/terminal points size in random walk.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
No new tests.

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
closes #927 