### PR TITLE
Lift restriction on projection, allow passing conn

### DIFF
--- a/cellrank/kernels/_connectivity_kernel.py
+++ b/cellrank/kernels/_connectivity_kernel.py
@@ -68,7 +68,11 @@ class ConnectivityKernel(ConnectivityMixin, UnidirectionalKernel):
         if self._reuse_cache({"dnorm": density_normalize, "key": self._conn_key}, time=start):
             return self
 
-        self.transition_matrix = self._density_normalize(self._conn) if density_normalize else self._conn
+        conn = self.connectivities
+        if density_normalize:
+            conn = self._density_normalize(conn)
+
+        self.transition_matrix = conn
         logg.info("    Finish", time=start)
         # fmt: on
 

--- a/cellrank/kernels/_pseudotime_kernel.py
+++ b/cellrank/kernels/_pseudotime_kernel.py
@@ -156,7 +156,7 @@ class PseudotimeKernel(ConnectivityMixin, BidirectionalKernel):
         # fmt: on
 
         biased_conn = scheme.bias_knn(
-            self._conn,
+            self.connectivities,
             self.pseudotime,
             n_jobs=n_jobs,
             backend=backend,

--- a/cellrank/kernels/_velocity_kernel.py
+++ b/cellrank/kernels/_velocity_kernel.py
@@ -199,7 +199,7 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel, ABC):
 
         if model == VelocityModel.DETERMINISTIC:
             return Deterministic(
-                self._conn,
+                self.connectivities,
                 self._xdata,
                 self._vdata,
                 similarity=similarity,
@@ -208,7 +208,7 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel, ABC):
             )
         if model == VelocityModel.STOCHASTIC:
             return Stochastic(
-                self._conn,
+                self.connectivities,
                 self._xdata,
                 self._vexp,
                 self._vvar,
@@ -218,7 +218,7 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel, ABC):
             )
         if model == VelocityModel.MONTE_CARLO:
             return MonteCarlo(
-                self._conn,
+                self.connectivities,
                 self._xdata,
                 self._vexp,
                 self._vvar,

--- a/cellrank/kernels/utils/__init__.py
+++ b/cellrank/kernels/utils/__init__.py
@@ -1,5 +1,5 @@
 from cellrank.kernels.utils._tmat_flow import FlowPlotter
-from cellrank.kernels.utils._projection import LowDimProjection
+from cellrank.kernels.utils._projection import TmatProjection
 from cellrank.kernels.utils._similarity import (
     Cosine,
     DotProduct,

--- a/cellrank/kernels/utils/_projection.py
+++ b/cellrank/kernels/utils/_projection.py
@@ -10,12 +10,12 @@ from cellrank.kernels._utils import _get_basis
 from scvelo.tools.velocity_embedding import quiver_autoscale
 
 import numpy as np
-from scipy.sparse import issparse
+from scipy.sparse import issparse, spmatrix, isspmatrix_csr
 
-__all__ = ["LowDimProjection"]
+__all__ = ["TmatProjection"]
 
 
-class LowDimProjection:
+class TmatProjection:
     """
     Project transition matrix onto a low-dimensional embedding.
 
@@ -34,10 +34,11 @@ class LowDimProjection:
 
         for kernel in kexpr.kernels:
             if not isinstance(kernel, ConnectivityMixin):
-                raise TypeError(
-                    f"{kernel!r} is not a kNN based kernel. The embedding projection "
-                    "only works for kNN based kernels."
+                logg.warning(
+                    f"{kernel!r} is not a kNN based kernel. "
+                    f"The embedding projection works best for kNN-based kernels"
                 )
+                break
         self._kexpr = kexpr
         self._basis = basis[2:] if basis.startswith("X_") else basis
         self._key: Optional[str] = None
@@ -46,9 +47,12 @@ class LowDimProjection:
         self,
         key_added: Optional[str] = None,
         recompute: bool = False,
+        connectivities: Optional[spmatrix] = None,
     ) -> None:
         """
         Project transition matrix onto an embedding.
+
+        This function has been adapted from :func:`scvelo.tl.velocity_embedding`.
 
         Parameters
         ----------
@@ -56,31 +60,45 @@ class LowDimProjection:
             Key in :attr:`anndata.AnnData.obsm` where to store the projection.
         recompute
             Whether to recompute the projection if it already exists.
+        connectivities
+            Connectivity matrix to use for projection. If ``None``, use ones from the underlying kernel, is possible.
 
         Returns
         -------
         Nothing, just updates :attr:`anndata.AnnData` with the projection and the parameters used for computation.
         """
-        # modified from: https://github.com/theislab/scvelo/blob/master/scvelo/tools/velocity_embedding.py
+        from cellrank.kernels.mixins import ConnectivityMixin
 
         self._key = Key.uns.kernel(self._kexpr.backward, key=key_added)
         ukey = f"{self._key}_params"
-        key = self._key + "_" + self._basis
+        key = f"{self._key}_{self._basis}"
 
         if not recompute and key in self._kexpr.adata.obsm:
             logg.info(f"Using precomputed projection `adata.obsm[{key!r}]`")
             return
 
         start = logg.info(f"Projecting transition matrix onto `{self._basis}`")
+        if connectivities is None:
+            try:
+                connectivities, *_ = (
+                    c.connectivities
+                    for c in self._kexpr.kernels
+                    if isinstance(c, ConnectivityMixin)
+                )
+            except ValueError:
+                raise RuntimeError(
+                    "Unable to find connectivities in the kernel. "
+                    "Please supply them as `connectivities=...`."
+                ) from None
+        if not isspmatrix_csr(connectivities):
+            connectivities = connectivities.tocsr()
 
         emb = _get_basis(self._kexpr.adata, self._basis)
         T_emb = np.empty_like(emb)
-        conn = self._kexpr.kernels[0]._conn
-
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             for row_id, row in enumerate(self._kexpr.transition_matrix):
-                conn_idxs = conn[row_id, :].indices
+                conn_idxs = connectivities[row_id, :].indices
 
                 dX = emb[conn_idxs] - emb[row_id, None]
 
@@ -122,7 +140,7 @@ class LowDimProjection:
             If ``True``, use :func:`scvelo.pl.velocity_embedding_stream`.
             Otherwise, use :func:`scvelo.pl.velocity_embedding_grid`.
         kwargs
-            Keyword argument for the plotting function.
+            Keyword argument for the chosen plotting function.
 
         Returns
         -------

--- a/docs/source/release/notes-dev.rst
+++ b/docs/source/release/notes-dev.rst
@@ -1,4 +1,4 @@
-CellRank dev (2022-06-29)
+CellRank dev (2022-07-08)
 =========================
 
 Features
@@ -64,6 +64,9 @@ Bugfixes
 
 - Adds references to the docs
   `#887 <https://github.com/theislab/cellrank/pull/887>`__
+
+- Fix computing time to absorption to aggregated terminal states.
+  `#923 <https://github.com/theislab/cellrank/pull/923>`__
 
 
 Miscellaneous

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -106,13 +106,10 @@ class TestOTKernel:
             ck = connectivity_kernel(adata_large).compute_transition_matrix()
             combined_kernel = 0.9 * ok + 0.1 * ck
             combined_kernel.compute_transition_matrix()
-        else:
-            combined_kernel = ok
-
-        with pytest.raises(
-            TypeError, match=r"StationaryOTKernel is not a kNN based kernel"
-        ):
             combined_kernel.plot_projection()
+        else:
+            with pytest.raises(RuntimeError, match=r"Unable to find connectivities"):
+                ok.plot_projection()
 
 
 @wot_not_installed_skip
@@ -180,7 +177,6 @@ class TestWOTKernel:
             elif cmat == "X_pca":
                 assert param == "obsm:X_pca"
             elif cmat == "good_shape":
-                # careful, param is `nstr`, which does not equal anything
                 assert str(param) == "precomputed"
             else:
                 assert param == "default"
@@ -326,11 +322,10 @@ class TestWOTKernel:
             ck = connectivity_kernel(adata_large).compute_transition_matrix()
             combined_kernel = 0.9 * ok + 0.1 * ck
             combined_kernel.compute_transition_matrix()
-        else:
-            combined_kernel = ok
-
-        with pytest.raises(TypeError, match=r"WOTKernel is not a kNN based kernel"):
             combined_kernel.plot_projection()
+        else:
+            with pytest.raises(RuntimeError, match=r"Unable to find connectivities"):
+                ok.plot_projection()
 
     def test_wot_write(self, adata_large: AnnData, tmpdir):
         path = str(tmpdir / "wot.pickle")

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1486,6 +1486,11 @@ class TestPrecomputedKernel:
         assert key in pk.params["origin"]
         np.testing.assert_array_equal(mat, pk.transition_matrix)
 
+    def test_projection_explicit_connectivities(self, adata: AnnData):
+        mat = random_transition_matrix(adata.n_obs)
+        pk = PrecomputedKernel(mat, adata=adata)
+        pk.plot_projection(connectivities=adata.obsp["connectivities"])
+
 
 class TestKernelIO:
     @pytest.mark.parametrize("copy", [False, True])

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -490,7 +490,7 @@ class TestKernel:
         k = clazz(**kwargs)
 
         if isinstance(k, ConnectivityMixin):
-            np.testing.assert_array_equal(k._conn.A, conn.A)
+            np.testing.assert_array_equal(k.connectivities.A, conn.A)
         else:
             assert not hasattr(k, "_conn")
 
@@ -816,7 +816,7 @@ class TestKernelCopy:
 
         for attr in ignored:
             assert getattr(ck2, attr, None) is None
-        assert ck2._conn is not None
+        assert ck2.connectivities is not None
         assert ck2._conn_key == ck1._conn_key
 
 


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Allow passing connectivities for transition matrix projection. Useful when the kernel is not kNN-based.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
1 new test, modified existing tests.

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
closes #928