### PR TITLE
Fix import issue with 'Iterable' from 'collections'

### DIFF
--- a/cellrank/pl/_heatmap.py
+++ b/cellrank/pl/_heatmap.py
@@ -5,7 +5,8 @@ import os
 from enum import auto
 from math import fabs
 from pathlib import Path
-from collections import Iterable, defaultdict
+from collections import defaultdict
+from collections.abc import Iterable
 
 from anndata import AnnData
 from cellrank import logging as logg


### PR DESCRIPTION
'Iterable' has moved from 'collections' to 'collections.abc' since
Python 3.9

Resolves #942

## Description
Import `Iterable` from `collections.abc` and not `collections`. `Iterable` was removed from `collections` in Python 3.10

## How has this been tested?
Tested on Python 3.10 and 3.9

## Closes
#942 
