### PR TITLE
Allow for nan values in `_black_or_white`

### DIFF
--- a/cellrank/_utils/_colors.py
+++ b/cellrank/_utils/_colors.py
@@ -136,6 +136,8 @@ def _contrasting_color(r: int, g: int, b: int) -> str:
 
 
 def _get_black_or_white(value: float, cmap) -> str:
+    if np.isnan(value):
+        return "#000000"
     if not (0.0 <= value <= 1.0):
         raise ValueError(f"Value must be in range `[0, 1]`, found `{value}`.")
 


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Allow NaN values when determining foreground/background color.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
No test added.

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
closes #946