### PR TITLE
Fix `isort` failure in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: black
         additional_dependencies: [toml]
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         additional_dependencies: [toml]

--- a/cellrank/_utils/_lineage.py
+++ b/cellrank/_utils/_lineage.py
@@ -531,7 +531,7 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
 
     @property
     def nlin(self) -> int:
-        """The number of lineages."""  # noqa: D401
+        """The number of lineages."""
         return self.shape[1]
 
     @d.get_full_description(base="lin_pd")

--- a/cellrank/estimators/terminal_states/_term_states_estimator.py
+++ b/cellrank/estimators/terminal_states/_term_states_estimator.py
@@ -68,7 +68,7 @@ class TermStatesEstimator(BaseEstimator, ABC):
     @property
     @d.get_summary(base="tse_term_states_probs")
     def terminal_states_probabilities(self) -> Optional[pd.Series]:
-        """Aggregated probability of cells to be in terminal states."""  # noqa: D401
+        """Aggregated probability of cells to be in terminal states."""
         return self._term_states_probs
 
     @d.dedent

--- a/cellrank/models/_base_model.py
+++ b/cellrank/models/_base_model.py
@@ -238,7 +238,7 @@ class BaseModel(IOMixin, ABC, metaclass=BaseModelMeta):
 
     @property
     def shape(self) -> Tuple[int]:
-        """Number of cells in :attr:`adata`."""  # noqa: D401
+        """Number of cells in :attr:`adata`."""
         return (self._n_obs,)
 
     @property
@@ -267,19 +267,19 @@ class BaseModel(IOMixin, ABC, metaclass=BaseModelMeta):
     @property
     @d.get_summary(base="base_model_x")
     def x(self) -> np.ndarray:
-        """Filtered independent variables of shape `(n_filtered_cells, 1)` used for fitting."""  # noqa
+        """Filtered independent variables of shape `(n_filtered_cells, 1)` used for fitting."""
         return self._x
 
     @property
     @d.get_summary(base="base_model_y")
     def y(self) -> np.ndarray:
-        """Filtered dependent variables of shape `(n_filtered_cells, 1)` used for fitting."""  # noqa
+        """Filtered dependent variables of shape `(n_filtered_cells, 1)` used for fitting."""
         return self._y
 
     @property
     @d.get_summary(base="base_model_w")
     def w(self) -> np.ndarray:
-        """Filtered weights of shape `(n_filtered_cells,)` used for fitting."""  # noqa
+        """Filtered weights of shape `(n_filtered_cells,)` used for fitting."""
         return self._w
 
     @property

--- a/cellrank/models/_sklearn_model.py
+++ b/cellrank/models/_sklearn_model.py
@@ -229,7 +229,7 @@ class SKLearnModel(BaseModel):
 
     @property
     def model(self) -> BaseEstimator:
-        """The underlying :class:`sklearn.base.BaseEstimator`."""  # noqa
+        """The underlying :class:`sklearn.base.BaseEstimator`."""
         return self._model
 
     @d.dedent


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->

* Bumps `isort` to `5.12.0`.

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->

Closes #993.