### PR TITLE
allow data and velocity to be read from obsm (as needed for MongeVelo…

### DIFF
--- a/cellrank/kernels/_velocity_kernel.py
+++ b/cellrank/kernels/_velocity_kernel.py
@@ -76,11 +76,7 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
     ) -> None:
         super()._read_from_adata(**kwargs)
 
-        if attr not in ["layers", "obsm"]:
-            raise ValueError(
-                f"Invalid attribute `{attr!r}`. Valid options are: `'obsm', 'layers'`."
-            )
-        elif (
+        if (
             attr == "layers"
             and gene_subset is None
             and f"{vkey}_genes" in self.adata.var
@@ -95,9 +91,11 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
 
         self._xdata = self._extract_data(key=xkey, attr=attr, subset=gene_subset)
         self._vdata = self._extract_data(key=vkey, attr=attr, subset=gene_subset)
-        assert np.all(
-            self._xdata.shape == self._vdata.shape
-        ), f"Shape mismatch: {self._xdata.shape} vs {self._vdata.shape}"
+        assert np.testing.assert_array_equal(
+            x=self._xdata.shape,
+            y=self._vdata.shape,
+            err_msg=f"Shape mismatch: {self._xdata.shape} vs {self._vdata.shape}",
+        )
 
         nans = np.isnan(np.sum(self._vdata, axis=0))
         if np.any(nans):

--- a/cellrank/kernels/_velocity_kernel.py
+++ b/cellrank/kernels/_velocity_kernel.py
@@ -84,14 +84,14 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
             gene_subset = self.adata.var[f"{vkey}_genes"]
         elif attr == "obsm" and gene_subset is not None:
             logg.warning(
-                "Found `gene_subset = {model!r}` but `gene_subset` is not supported for `attr = {model!r}`. "
-                "Setting `gene_subset = None`."
+                f"Found `gene_subset = {gene_subset!r}` but `gene_subset` is not supported for "
+                f"`attr = {gene_subset!r}`. Setting `gene_subset = None`."
             )
             gene_subset = None
 
         self._xdata = self._extract_data(key=xkey, attr=attr, subset=gene_subset)
         self._vdata = self._extract_data(key=vkey, attr=attr, subset=gene_subset)
-        assert np.testing.assert_array_equal(
+        np.testing.assert_array_equal(
             x=self._xdata.shape,
             y=self._vdata.shape,
             err_msg=f"Shape mismatch: {self._xdata.shape} vs {self._vdata.shape}",

--- a/cellrank/kernels/_velocity_kernel.py
+++ b/cellrank/kernels/_velocity_kernel.py
@@ -90,6 +90,9 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
 
         self._xdata = self._extract_data(key=xkey, attr=attr, subset=gene_subset)
         self._vdata = self._extract_data(key=vkey, attr=attr, subset=gene_subset)
+        assert np.all(
+            self._xdata.shape == self._vdata.shape
+        ), f"Shape mismatch: {self._xdata.shape} vs {self._vdata.shape}"
 
         nans = np.isnan(np.sum(self._vdata, axis=0))
         if np.any(nans):

--- a/cellrank/kernels/_velocity_kernel.py
+++ b/cellrank/kernels/_velocity_kernel.py
@@ -32,8 +32,7 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
     %(adata)s
     %(backward)s
     attr
-        Attribute of `anndata.AnnData` to be read from. Should be `anndata.AnnData.layers` or `anndata.AnnData.obsm`.
-        Default is `anndata.AnnData.layers`.
+        Attribute of :class:`~anndata.AnnData` to read from.
     xkey
         Key in :attr:`anndata.AnnData.layers` or :attr:`anndata.AnnData.obsm` where expected gene expression counts are
         stored.
@@ -42,7 +41,7 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
     gene_subset
         List of genes to be used to compute transition probabilities.
         If not specified, genes from :attr:`anndata.AnnData.var` ``['{vkey}_genes']`` are used.
-        This feature is only available when reading from `anndata.AnnData.layers` and will be ignored otherwise.
+        This feature is only available when reading from :attr:`anndata.AnnData.layers` and will be ignored otherwise.
     kwargs
         Keyword arguments for the parent class.
     """
@@ -51,9 +50,9 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
         self,
         adata: AnnData,
         backward: bool = False,
+        attr: Optional[Literal["layers", "obsm"]] = "layers",
         xkey: Optional[str] = "Ms",
         vkey: Optional[str] = "velocity",
-        attr: Optional[Literal["layers", "obsm"]] = "layers",
         **kwargs: Any,
     ):
         super().__init__(
@@ -84,8 +83,7 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
             gene_subset = self.adata.var[f"{vkey}_genes"]
         elif attr == "obsm" and gene_subset is not None:
             logg.warning(
-                f"Found `gene_subset = {gene_subset!r}` but `gene_subset` is not supported for "
-                f"`attr = {gene_subset!r}`. Setting `gene_subset = None`."
+                f"Found `gene_subset != None`, but it is not supported for `adata.{attr}`. Using `gene_subset = None`."
             )
             gene_subset = None
 
@@ -276,7 +274,7 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
         elif attr == "obsm" and key in self.adata.obsm:
             data = np.asarray(self.adata.obsm[key])
         else:
-            raise KeyError(f"Unable to find data in `adata.layers[{key}]`.")
+            raise KeyError(f"Unable to find data in `adata.{attr}[{key!r}]`.")
 
         if subset is not None:
             if isinstance(subset, str):

--- a/cellrank/kernels/_velocity_kernel.py
+++ b/cellrank/kernels/_velocity_kernel.py
@@ -31,13 +31,18 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
     ----------
     %(adata)s
     %(backward)s
+    attr
+        Attribute of `anndata.AnnData` to be read from. Should be `anndata.AnnData.layers` or `anndata.AnnData.obsm`.
+        Default is `anndata.AnnData.layers`.
     xkey
-        Key in :attr:`anndata.AnnData.layers` where expected gene expression counts are stored.
+        Key in :attr:`anndata.AnnData.layers` or :attr:`anndata.AnnData.obsm` where expected gene expression counts are
+        stored.
     vkey
-        Key in :attr:`anndata.AnnData.layers` where velocities are stored.
+        Key in :attr:`anndata.AnnData.layers` or :attr:`anndata.AnnData.obsm` where velocities are stored.
     gene_subset
         List of genes to be used to compute transition probabilities.
         If not specified, genes from :attr:`anndata.AnnData.var` ``['{vkey}_genes']`` are used.
+        This feature is only available when reading from `anndata.AnnData.layers` and will be ignored otherwise.
     kwargs
         Keyword arguments for the parent class.
     """

--- a/docs/source/release/notes-dev.rst
+++ b/docs/source/release/notes-dev.rst
@@ -1,4 +1,4 @@
-CellRank dev (2023-03-23)
+CellRank dev (2023-03-26)
 =========================
 
 Features

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -709,8 +709,8 @@ class TestVelocityKernelReadData:
         attr: Literal["layers", "obsm"],
         use_gene_subset: bool,
     ):
-        xkey = ("Ms",)
-        vkey = ("velocity",)
+        xkey = "Ms"
+        vkey = "velocity"
         if attr == "layers":
             nans_v = np.isnan(np.sum(adata.layers[vkey], axis=0))
         else:  # attr == "obsm"

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -716,11 +716,11 @@ class TestVelocityKernelReadData:
             attr="layers",
             gene_subset=None,
         )
-        assert np.all(
-            vk._xdata == adata.layers[xkey][:, np.asarray(gene_subset) & ~nans_v]
+        np.testing.assert_array_equal(
+            x=vk._xdata, y=adata.layers[xkey][:, np.asarray(gene_subset) & ~nans_v]
         )
-        assert np.all(
-            vk._vdata == adata.layers[vkey][:, np.asarray(gene_subset) & ~nans_v]
+        np.testing.assert_array_equal(
+            x=vk._vdata, y=adata.layers[vkey][:, np.asarray(gene_subset) & ~nans_v]
         )
 
         vk_red = VelocityKernel(
@@ -731,13 +731,13 @@ class TestVelocityKernelReadData:
             gene_subset=gene_subset_reduced,
         )
 
-        assert np.all(
-            vk_red._vdata
-            == adata.layers[vkey][:, np.asarray(gene_subset_reduced) & ~nans_v]
+        np.testing.assert_array_equal(
+            x=vk_red._vdata,
+            y=adata.layers[vkey][:, np.asarray(gene_subset_reduced) & ~nans_v],
         )
-        assert np.all(
-            vk_red._xdata
-            == adata.layers[xkey][:, np.asarray(gene_subset_reduced) & ~nans_v]
+        np.testing.assert_array_equal(
+            x=vk_red._xdata,
+            y=adata.layers[xkey][:, np.asarray(gene_subset_reduced) & ~nans_v],
         )
 
     def test_read_correct_from_obsm(self, adata: AnnData):
@@ -754,8 +754,8 @@ class TestVelocityKernelReadData:
             attr="obsm",
             gene_subset=None,
         )
-        assert np.all(vk._xdata == adata.obsm[xkey][:, ~nans_v])
-        assert np.all(vk._vdata == adata.obsm[vkey][:, ~nans_v])
+        np.testing.assert_array_equal(x=vk._xdata, y=adata.obsm[xkey][:, ~nans_v])
+        np.testing.assert_array_equal(x=vk._vdata, y=adata.obsm[vkey][:, ~nans_v])
 
         vk_red = VelocityKernel(
             adata,
@@ -764,8 +764,8 @@ class TestVelocityKernelReadData:
             attr="obsm",
             gene_subset=gene_subset,
         )
-        assert np.all(vk_red._xdata == vk._xdata)
-        assert np.all(vk_red._vdata == vk._vdata)
+        np.testing.assert_array_equal(x=vk_red._xdata, y=vk._xdata)
+        np.testing.assert_array_equal(x=vk_red._vdata, y=vk._vdata)
 
 
 class TestKernelAddition:

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -733,11 +733,15 @@ class TestVelocityKernelReadData:
             gene_subset=gene_subset,
         )
         if attr == "layers":
+            if use_gene_subset:
+                _subset = np.asarray(gene_subset)
+            else:
+                _subset = np.asarray(adata.var[f"{vkey}_genes"])
             np.testing.assert_array_equal(
-                x=vk._xdata, y=adata.layers[xkey][:, np.asarray(gene_subset) & ~nans_v]
+                x=vk._xdata, y=adata.layers[xkey][:, _subset & ~nans_v]
             )
             np.testing.assert_array_equal(
-                x=vk._vdata, y=adata.layers[vkey][:, np.asarray(gene_subset) & ~nans_v]
+                x=vk._vdata, y=adata.layers[vkey][:, _subset & ~nans_v]
             )
         else:
             np.testing.assert_array_equal(x=vk._xdata, y=adata.obsm[xkey][:, ~nans_v])

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -706,11 +706,11 @@ class TestVelocityKernelReadData:
     def test_read_correct_from_layers(
         self,
         adata: AnnData,
-        attr: str,
+        attr: Literal["layers", "obsm"],
         use_gene_subset: bool,
-        xkey: str = "Ms",
-        vkey: str = "velocity",
     ):
+        xkey = ("Ms",)
+        vkey = ("velocity",)
         if attr == "layers":
             nans_v = np.isnan(np.sum(adata.layers[vkey], axis=0))
         else:  # attr == "obsm"
@@ -722,13 +722,15 @@ class TestVelocityKernelReadData:
         gene_subset = adata.var[f"{vkey}_genes"]
         if use_gene_subset:
             gene_subset[10:] = False
+        else:
+            gene_subset = None
 
         vk = VelocityKernel(
             adata,
             xkey=xkey,
             vkey=vkey,
             attr=attr,
-            gene_subset=(None if not use_gene_subset else gene_subset),
+            gene_subset=gene_subset,
         )
         if attr == "layers":
             np.testing.assert_array_equal(

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, Tuple, Union, Callable, Optional
+from typing import Any, Type, Tuple, Union, Literal, Callable, Optional
 
 import pickle
 import pytest


### PR DESCRIPTION
…cities)

**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
Changes in `_velocity_kernel.py` so that data can optionally be read from `obsm`. This is needed for MongeVelocities where the dimension of the velocities may differ from the dimension of `adata.X` so that they cannot be stored in `adata.layers` but only in `adata.obsm`. Defaults are set so that the new implementation matches the original implementation.

## How has this been tested?
So far I have only tested that 
```python
import numpy as np
import jax.numpy as jnp
import scanpy as sc
import scvelo as scv
import cellrank as cr
from cellrank.kernels import VelocityKernel
from moscot.datasets import simulate_data

adata = cr.datasets.pancreas_preprocessed()
scv.utils.show_proportions(adata)
vk = VelocityKernel(adata)
vk.compute_transition_matrix()
```
as well as 
```python
import numpy as np
import jax.numpy as jnp
import scanpy as sc
import scvelo as scv
import cellrank as cr
from cellrank.kernels import VelocityKernel
from moscot.datasets import simulate_data

adata = simulate_data(
    n_distributions=2,
    cells_per_distribution=40,
    n_genes=60,
    key="batch",
)

sc.pp.pca(adata, n_comps=30)
sc.pp.neighbors(adata)

from moscot.problems.time import TemporalNeuralProblem
tnp = TemporalNeuralProblem(adata)
tnp = tnp.prepare(time_key="batch", joint_attr = "X_pca")
tnp = tnp.solve(tau_a=1, tau_b=1, iterations=3)
source = jnp.array(adata.obsm["X_pca"].copy())
velocity = tnp[('0', '1')].solution.push(source) - source


tnp.adata.obsm["Monge_velocities"] = velocity

vk = VelocityKernel(adata, xkey="X_pca", vkey="Monge_velocities", attr="obsm")
vk.compute_transition_matrix()
```
run without error. Whether the output is correct has so far not been tested.


This PR replaces a older, separate PR which implemented a separate `MongeKernel`: https://github.com/theislab/cellrank/pull/1017 We realized that the `MongeKernel` is essentially identical to the `VelocityKernel` if we allow data to be read from `adata.obsm`.
