### PR TITLE
Fix error message about allowed plotting types

### DIFF
--- a/cellrank/estimators/terminal_states/_term_states_estimator.py
+++ b/cellrank/estimators/terminal_states/_term_states_estimator.py
@@ -360,7 +360,7 @@ class TermStatesEstimator(BaseEstimator, ABC):
         else:
             raise ValueError(
                 f"Unable to plot `{which!r}` states. "
-                f"Valid options are: `{['macro', 'initial', 'terminal']}`."
+                f"Valid options are: `{['all', 'initial', 'terminal']}`."
             )
 
         name = "macrostates" if which == "macro" else f"{which} states"


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
Very minor fix to adapt the allowed options in macrostate plotting. 

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
