### PR TITLE
Fix gene trends colors

### DIFF
--- a/cellrank/pl/_gene_trend.py
+++ b/cellrank/pl/_gene_trend.py
@@ -189,7 +189,6 @@ def gene_trends(
         cbar = False
         logg.debug("All lineages are `None`, setting the weights to `1`")
     lineages = _unique_order_preserving(lineages)
-    probs = probs[lineages]
 
     if isinstance(time_range, (tuple, float, int, type(None))):
         time_range = [time_range] * len(lineages)
@@ -221,6 +220,7 @@ def gene_trends(
     )
 
     lineages = sorted(lineages)
+    probs = probs[lineages]
     if lineage_cmap is None and not transpose:
         lineage_cmap = probs.colors
 


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Fix lineage color map in :func:`cellrank.pl.gene_trends`.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
No new tests.

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
closes #1042