### PR TITLE
expose pygam model penalties via spline_kwargs fixes #1126

### DIFF
--- a/src/cellrank/models/_pygam_model.py
+++ b/src/cellrank/models/_pygam_model.py
@@ -106,8 +106,7 @@ class GAM(BaseModel):
             0,
             spline_order=spline_order,
             n_splines=n_knots,
-            penalties=["derivative", "l2"],
-            **_filter_kwargs(s, **{**{"lam": 3}, **spline_kwargs}),
+            **_filter_kwargs(s, **{**{"lam": 3, "penalties": ["derivative", "l2"]}, **spline_kwargs}),
         )
         link = GamLinkFunction(link)
         distribution = GamDistribution(distribution)


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
Expose pygam model penalties via spline_kwargs. Before it was set to `penalties=["derivative", "l2"]` in the code. Now, the user can change the default by using: `spline_kwargs={'penalties':['derivative']}`

## How has this been tested?
Tested with my own data pipeline. Does not change default parameter.

## Closes
closes #1126
