### PR TITLE
chore: bump ruff pre-commit hook version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ docs/api/_autosummary
 
 # tests
 tests/figures
+
+# Ruff
+.ruff_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,8 +56,8 @@ repos:
   rev: v1.1.1
   hooks:
   - id: doc8
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.270
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.6.3
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,9 @@ include-package-data = true
 
 [tool.ruff]
 target-version = "py38"
+line-length = 120
+
+[tool.ruff.lint]
 exclude = [
     ".eggs",
     ".git",
@@ -136,7 +139,6 @@ ignore = [
     # Missing docstring in magic method
     "D105",
 ]
-line-length = 120
 select = [
     "D", # flake8-docstrings
     "E", # pycodestyle
@@ -155,15 +157,15 @@ select = [
     "RET", # flake8-raise
 ]
 unfixable = ["B", "UP", "C4", "BLE", "T20", "RET"]
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D"]
 "*/__init__.py" = ["F401"]
 "docs/*" = ["D"]
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 inline-quotes = "double"
 
 [tool.black]


### PR DESCRIPTION
## Description

Hi, this is my first PR to the project. Please let me know, if the changes are desired.

This PR bumps the ruff version in your pre-commit config. With that change the configuration needs to be updated as well to silence a few warnings (e.g. their is now a section `tool.ruff.lint`).

A few rule changes make the codebase now fail the linting step. Would you like to me to fix those? What do you think?

See: https://docs.astral.sh/ruff/configuration/

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
