### PR TITLE
Fix `TestRealTimeKernel::test_explicit_shuffle`

### DIFF
--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1209,7 +1209,8 @@ class TestRealTimeKernel:
         tmat = tmk.transition_matrix
 
         for src, tgt in zip(cats[:-1], cats[1:]):
-            src_mask, tgt_mask = tmk.time == src, tmk.time == tgt
+            src_mask = (tmk.time == src).tolist()
+            tgt_mask = (tmk.time == tgt).tolist()
             np.testing.assert_allclose(tmat[src_mask, :][:, tgt_mask].toarray(), expected[src, tgt])
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->

Update `TestRealTimeKernel::test_explicit_shuffle` to convert Pandas Series to a list before subsetting sparse matrix.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
Closes #1251.