### PR TITLE
fix np str repr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12', '3.13']
         slepc: [noslepc]
         include:
         - os: macos-15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "cellrank"
 dynamic = ["version"]
 description = "CellRank: dynamics from multi-view single-cell data"
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 classifiers = [
@@ -20,10 +20,10 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Typing :: Typed",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Visualization",
@@ -240,7 +240,7 @@ legacy_tox_ini = """
 # TODO(michalk8): upgrade to `tox>=4.0` once `tox-conda` supports it
 requires = tox-conda
 isolated_build = true
-envlist = lint-code,py{3.9,3.10,3.11,3.12,3.13}-{slepc,noslepc}
+envlist = lint-code,py{3.10,3.11,3.12,3.13}-{slepc,noslepc}
 skip_missing_interpreters = true
 
 [testenv]

--- a/src/cellrank/_utils/_lineage.py
+++ b/src/cellrank/_utils/_lineage.py
@@ -1005,6 +1005,7 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
         default: Optional[Union[int, str]] = None,
         make_unique: bool = True,
     ) -> Union[int, list[int], list[bool]]:
+        """Convert string indices to their corresponding int indices."""
         from cellrank._utils._utils import _unique_order_preserving
 
         if all(isinstance(n, (bool, np.bool_)) for n in names):
@@ -1016,12 +1017,11 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
                     name = self._names_to_ixs[name]
                 elif default is not None:
                     if isinstance(default, str):
-                        str_default = str(default)
-                        if str_default not in self._names_to_ixs:
+                        if default not in self._names_to_ixs:
                             raise KeyError(
                                 f"Invalid lineage name: `{name}`. Valid names are: `{[str(n) for n in self.names]}`."
                             )
-                        name = self._names_to_ixs[str_default]
+                        name = self._names_to_ixs[default]
                     else:
                         name = default
                 else:
@@ -1029,8 +1029,10 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
                         f"Invalid lineage name `{name!r}`. Valid names are: `{[str(n) for n in self.names]}`."
                     )
             res.append(name)
+
         if make_unique:
             res = _unique_order_preserving(res)
+
         return res[0] if is_singleton else res
 
     @staticmethod

--- a/src/cellrank/_utils/_lineage.py
+++ b/src/cellrank/_utils/_lineage.py
@@ -1005,7 +1005,6 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
         default: Optional[Union[int, str]] = None,
         make_unique: bool = True,
     ) -> Union[int, list[int], list[bool]]:
-        """Convert string indices to their corresponding int indices."""
         from cellrank._utils._utils import _unique_order_preserving
 
         if all(isinstance(n, (bool, np.bool_)) for n in names):
@@ -1017,20 +1016,21 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
                     name = self._names_to_ixs[name]
                 elif default is not None:
                     if isinstance(default, str):
-                        if default not in self._names_to_ixs:
+                        str_default = str(default)
+                        if str_default not in self._names_to_ixs:
                             raise KeyError(
-                                f"Invalid lineage name: `{name}`. " f"Valid names are: `{list(self.names)}`."
+                                f"Invalid lineage name: `{name}`. Valid names are: `{[str(n) for n in self.names]}`."
                             )
-                        name = self._names_to_ixs[default]
+                        name = self._names_to_ixs[str_default]
                     else:
                         name = default
                 else:
-                    raise KeyError(f"Invalid lineage name `{name!r}`. Valid names are: `{list(self.names)}`.")
+                    raise KeyError(
+                        f"Invalid lineage name `{name!r}`. Valid names are: `{[str(n) for n in self.names]}`."
+                    )
             res.append(name)
-
         if make_unique:
             res = _unique_order_preserving(res)
-
         return res[0] if is_singleton else res
 
     @staticmethod


### PR DESCRIPTION
- Deprecates Python 3.9 which is EOL. To be honest, I would jump immediately to 3.11+ (spec-0) or even 3.12+ (spec-0 in 2 months)
- Fixes https://github.com/theislab/cellrank/issues/1261