### PR TITLE
Refactor `assert_array_equal` calls

### DIFF
--- a/src/cellrank/kernels/_velocity_kernel.py
+++ b/src/cellrank/kernels/_velocity_kernel.py
@@ -92,8 +92,8 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
         self._xdata = self._extract_data(key=xkey, attr=attr, subset=gene_subset)
         self._vdata = self._extract_data(key=vkey, attr=attr, subset=gene_subset)
         np.testing.assert_array_equal(
-            x=self._xdata.shape,
-            y=self._vdata.shape,
+            self._xdata.shape,
+            self._vdata.shape,
             err_msg=f"Shape mismatch: {self._xdata.shape} vs {self._vdata.shape}",
         )
 

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -639,11 +639,11 @@ class TestVelocityKernelReadData:
         )
         if attr == "layers":
             _subset = np.asarray(gene_subset) if use_gene_subset else np.asarray(adata.var[f"{vkey}_genes"])
-            np.testing.assert_array_equal(x=vk._xdata, y=adata.layers[xkey][:, _subset & ~nans_v])
-            np.testing.assert_array_equal(x=vk._vdata, y=adata.layers[vkey][:, _subset & ~nans_v])
+            np.testing.assert_array_equal(vk._xdata, adata.layers[xkey][:, _subset & ~nans_v])
+            np.testing.assert_array_equal(vk._vdata, adata.layers[vkey][:, _subset & ~nans_v])
         else:
-            np.testing.assert_array_equal(x=vk._xdata, y=adata.obsm[xkey][:, ~nans_v])
-            np.testing.assert_array_equal(x=vk._vdata, y=adata.obsm[vkey][:, ~nans_v])
+            np.testing.assert_array_equal(vk._xdata, adata.obsm[xkey][:, ~nans_v])
+            np.testing.assert_array_equal(vk._vdata, adata.obsm[vkey][:, ~nans_v])
 
 
 class TestKernelAddition:


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Bug fixes
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->

* Remove explicit keyword argument `x` and `y` from `assert_almost_equal`.

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->

Closes #1272.