### PR TITLE
Fix petsc unit test

### DIFF
--- a/tests/test_linear_solver.py
+++ b/tests/test_linear_solver.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 import numpy as np
@@ -102,7 +104,8 @@ class TestScipyLinearSolver:
 @petsc_slepc_skip
 class TestLinearSolverPETSc:
     def test_create_petsc_matrix_no_a_matrix(self):
-        with pytest.raises(TypeError, match="integer is required"):
+        expected_log = re.escape("int() argument must be a string, a bytes-like object or a real number, not 'tuple'")
+        with pytest.raises(TypeError, match=expected_log):
             _create_petsc_matrix(np.empty((100,)))
 
     def test_create_petsc_matrix_from_dense(self):


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->

Update unit test `tests/test_linear_solver.py::TestLinearSolverPETSc::test_create_petsc_matrix_no_a_matrix`.

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->

Closes #1275.