### PR TITLE
Switch default optimizer to CG with multi-start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,10 @@ cython_debug/
 
 # VS Code
 .vscode/
+.github/prompts/
+
+# uv
+uv.lock
 
 # documentation
 docs/api/_autosummary

--- a/src/cellrank/estimators/terminal_states/_gpcca.py
+++ b/src/cellrank/estimators/terminal_states/_gpcca.py
@@ -161,9 +161,13 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
         n_cells: int | None = 30,
         cluster_key: str | Mapping[str, str] | None = None,
         weight_key: str | None = None,
+        optimizer: str = "CG",
+        n_starts: int = 10,
+        perturbation_scale: float = 0.1,
+        seed: int | None = None,
         **kwargs: Any,
     ) -> "GPCCA":
-        """Compute the macrostates.
+        r"""Compute the macrostates.
 
         Parameters
         ----------
@@ -197,6 +201,28 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
               count proportionally more. The weights can be any per-observation quantity; a common
               choice is the number of cells per aggregated sample, which makes naming reflect
               cell-level rather than sample-level dominance.
+        optimizer
+            Optimization method for the GPCCA rotation matrix. Valid options are
+            ``'CG'``, ``'L-BFGS-B'``, ``'BFGS'``, and ``'Nelder-Mead'``.
+            ``'CG'`` (conjugate gradient) uses an analytical Jacobian and scales
+            as :math:`O(n \cdot m^2)` per iteration, where *n* is the number of
+            cells and *m* is the number of macrostates.
+            ``'Nelder-Mead'`` is derivative-free and was the original default.
+            It optimizes over :math:`O(m^2)` rotation parameters and becomes
+            impractical for ``n_states > 15``.
+        n_starts
+            Number of optimization runs. The first run uses the deterministic
+            ISA initialization; subsequent runs perturb the initial rotation
+            matrix on the SO(k) manifold and keep the result with the best
+            crispness. Set to ``1`` to disable perturbation (fully
+            deterministic).
+        perturbation_scale
+            Angular scale for the rotation perturbation (only used when
+            ``n_starts > 1``). Recommended range is 0.05-0.2; larger values
+            risk producing degenerate solutions.
+        seed
+            Random seed for reproducibility of the perturbations
+            (only used when ``n_starts > 1``).
         kwargs
             Keyword arguments for :meth:`compute_schur`.
 
@@ -234,10 +260,23 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
                 self._gpcca._p_X.shape[1],
             )
 
+        if n_states > 15 and optimizer == "Nelder-Mead":
+            logger.warning(
+                "Using Nelder-Mead with `n_states=%s` may be very slow. "
+                "Consider using optimizer='CG' (the default) or another gradient-based optimizer",
+                n_states,
+            )
+
         _start = _time.perf_counter()
         logger.info("Computing %d macrostates", n_states)
         try:
-            self._gpcca = self._gpcca.optimize(m=n_states)
+            self._gpcca = self._gpcca.optimize(
+                m=n_states,
+                method=optimizer,
+                n_starts=n_starts,
+                perturbation_scale=perturbation_scale,
+                seed=seed,
+            )
         except ValueError as e:
             if "will split complex conjugate eigenvalues" not in str(e):
                 raise
@@ -250,7 +289,13 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
                 n_states,
                 n_states + 1,
             )
-            self._gpcca = self._gpcca.optimize(m=n_states + 1)
+            self._gpcca = self._gpcca.optimize(
+                m=n_states + 1,
+                method=optimizer,
+                n_starts=n_starts,
+                perturbation_scale=perturbation_scale,
+                seed=seed,
+            )
 
         self._set_macrostates(
             memberships=self._gpcca.memberships,
@@ -819,6 +864,10 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
         n_cells: int | None = 30,
         cluster_key: str | Mapping[str, str] | None = None,
         weight_key: str | None = None,
+        optimizer: str = "CG",
+        n_starts: int = 10,
+        perturbation_scale: float = 0.1,
+        seed: int | None = None,
         **kwargs: Any,
     ) -> "GPCCA":
         """
@@ -853,7 +902,14 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
         # when `minChi` is used for `n_states` and `self._gpcca` is uninitialized
         _ = self.compute_schur(n, **kwargs)
         return self.compute_macrostates(
-            n_states=n_states, cluster_key=cluster_key, weight_key=weight_key, n_cells=n_cells
+            n_states=n_states,
+            cluster_key=cluster_key,
+            weight_key=weight_key,
+            n_cells=n_cells,
+            optimizer=optimizer,
+            n_starts=n_starts,
+            perturbation_scale=perturbation_scale,
+            seed=seed,
         )
 
     @d.dedent


### PR DESCRIPTION
## Summary

Switch the default GPCCA rotation optimizer from Nelder-Mead to conjugate gradient (CG) with 10 random restarts. This makes `compute_macrostates()` scale to large numbers of macrostates (m > 15) where Nelder-Mead becomes impractical.

## Changes

- **Default optimizer**: `"Nelder-Mead"` → `"CG"`
- **Default n_starts**: `1` → `10` (with `perturbation_scale=0.1`)
- **New parameters** on `compute_macrostates()`: `n_starts`, `perturbation_scale`, `seed` — these were already supported by pyGPCCA but not exposed in CellRank
- **`fit()` method**: Now forwards optimizer parameters to `compute_macrostates()` (previously always used hardcoded defaults)
- **.gitignore**: Added `uv.lock` and `.github/prompts/`

## Benchmark results

Validated on pancreas (2,531 cells) and bone marrow (5,780 cells) datasets:

| m | NM 1× crispness (time) | CG 10×0.1 crispness (time) |
|---|---|---|
| 5 | 0.513 (0.1s) | 0.477 (0.2s) |
| 10 | 0.234 (1.6s) | 0.243 (0.4s) |
| 15 | 0.123 (13.7s) | 0.221 (2.2s) |
| 50 | infeasible | 0.063 (30.0s) |

- CG 10×0.1 matches or beats NM on crispness at m ≥ 8
- High membership agreement: mean Pearson r ≥ 0.94, Jaccard ≥ 0.70
- All CG solutions are non-degenerate (no empty clusters)
- Extrapolated: CG 10×0.1 at m=50, n=1M ≈ 3.3 hrs (NM infeasible)

## Dependencies

Requires pyGPCCA from `msmdev/pyGPCCA` branch `feature/gradient-optimization` which implements the analytical Jacobian and multi-start SO(k) rotation perturbation.
