### PR TITLE
Add deprecation warnings for CellRank 3.0

### DIFF
--- a/src/cellrank/estimators/_base_estimator.py
+++ b/src/cellrank/estimators/_base_estimator.py
@@ -71,6 +71,10 @@ class BaseEstimator(IOMixin, KernelMixin, AnnDataMixin, abc.ABC):
     def fit(self, *args: Any, **kwargs: Any) -> "BaseEstimator":
         """Fit the estimator.
 
+        .. deprecated:: 2.1
+            Will be removed in CellRank 3.0. Use the individual methods directly
+            (e.g., :meth:`compute_schur`, :meth:`compute_macrostates`).
+
         Parameters
         ----------
         args
@@ -86,6 +90,10 @@ class BaseEstimator(IOMixin, KernelMixin, AnnDataMixin, abc.ABC):
     @abc.abstractmethod
     def predict(self, *args: Any, **kwargs: Any) -> "BaseEstimator":
         """Run the prediction.
+
+        .. deprecated:: 2.1
+            Will be removed in CellRank 3.0. Use the individual methods directly
+            (e.g., :meth:`predict_terminal_states`).
 
         Parameters
         ----------

--- a/src/cellrank/estimators/terminal_states/_cflare.py
+++ b/src/cellrank/estimators/terminal_states/_cflare.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Sequence
 from typing import Any, Literal
 
@@ -38,9 +39,20 @@ class CFLARE(TermStatesEstimator, LinDriversMixin, EigenMixin):
     %(base_estimator.parameters)s
     """
 
+    def __init__(self, *args: Any, **kwargs: Any):
+        warnings.warn(
+            "CFLARE is deprecated and will be removed in CellRank 3.0. Use `cellrank.estimators.GPCCA` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
     @d.dedent
     def fit(self, k: int = 20, **kwargs: Any) -> "TermStatesEstimator":
         """Prepare self for terminal states prediction.
+
+        .. deprecated:: 2.1
+            Will be removed in CellRank 3.0. Use :meth:`compute_eigendecomposition` directly.
 
         Parameters
         ----------
@@ -55,6 +67,12 @@ class CFLARE(TermStatesEstimator, LinDriversMixin, EigenMixin):
 
         - :attr:`eigendecomposition` - %(eigen.summary)s
         """
+        warnings.warn(
+            "`CFLARE.fit()` is deprecated and will be removed in CellRank 3.0. "
+            "Use `CFLARE.compute_eigendecomposition()` directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.compute_eigendecomposition(k=k, only_evals=False, **kwargs)
 
     @d.dedent
@@ -74,6 +92,10 @@ class CFLARE(TermStatesEstimator, LinDriversMixin, EigenMixin):
         scale: bool | None = None,
     ) -> "CFLARE":
         """Find approximate recurrent classes of the Markov chain.
+
+        .. deprecated:: 2.1
+            Will be removed in CellRank 3.0. The entire :class:`CFLARE` estimator is
+            deprecated. Use :class:`cellrank.estimators.GPCCA` instead.
 
         Filter to obtain recurrent states from left eigenvectors.
         Cluster to obtain approximate recurrent classes from right eigenvectors.
@@ -121,6 +143,12 @@ class CFLARE(TermStatesEstimator, LinDriversMixin, EigenMixin):
         - :attr:`terminal_states` - %(tse_term_states.summary)s
         - :attr:`terminal_states_probabilities` - %(tse_term_states_probs.summary)s
         """
+        warnings.warn(
+            "`CFLARE.predict()` is deprecated and will be removed in CellRank 3.0. "
+            "Use `cellrank.estimators.GPCCA` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         def convert_use(use: int | Sequence[int] | np.ndarray | None) -> list[int]:
             if method not in ["kmeans", "leiden"]:

--- a/src/cellrank/estimators/terminal_states/_gpcca.py
+++ b/src/cellrank/estimators/terminal_states/_gpcca.py
@@ -3,6 +3,7 @@ import datetime
 import enum
 import pathlib
 import types
+import warnings
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Literal
@@ -223,6 +224,9 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
     def predict(self, *args: Any, **kwargs: Any) -> "GPCCA":
         """Alias for :meth:`predict_terminal_states`.
 
+        .. deprecated:: 2.1
+            Will be removed in CellRank 3.0. Use :meth:`predict_terminal_states` directly.
+
         Parameters
         ----------
         args
@@ -234,6 +238,12 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
         -------
         Same as :meth:`predict_terminal_states`.
         """
+        warnings.warn(
+            "`GPCCA.predict()` is deprecated and will be removed in CellRank 3.0. "
+            "Use `GPCCA.predict_terminal_states()` directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.predict_terminal_states(*args, **kwargs)
 
     @d.dedent
@@ -724,6 +734,10 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
         """
         Prepare self for terminal states prediction.
 
+        .. deprecated:: 2.1
+            Will be removed in CellRank 3.0. Use :meth:`compute_schur` and
+            :meth:`compute_macrostates` directly.
+
         Parameters
         ----------
         %(gpcca_compute_macro.parameters)s
@@ -732,6 +746,12 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
         -------
         %(gpcca_compute_macro.returns)s
         """
+        warnings.warn(
+            "`GPCCA.fit()` is deprecated and will be removed in CellRank 3.0. "
+            "Use `GPCCA.compute_schur()` and `GPCCA.compute_macrostates()` directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if n_states is None:
             self.compute_eigendecomposition()
             n_states = self.eigendecomposition["eigengap"] + 1

--- a/src/cellrank/kernels/_velocity_kernel.py
+++ b/src/cellrank/kernels/_velocity_kernel.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Callable, Sequence
 from typing import Any, Literal
 
@@ -142,6 +143,14 @@ class VelocityKernel(ConnectivityMixin, BidirectionalKernel):
         Returns self and updates :attr:`transition_matrix`, :attr:`logits` and :attr:`params`.
         """
         start = logg.info(f"Computing transition matrix using `{model!r}` model")
+
+        if VelocityModel(model) != VelocityModel.DETERMINISTIC:
+            warnings.warn(
+                f"model={model!r} is deprecated and will be removed in CellRank 3.0. "
+                "Use model='deterministic' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # fmt: off
         params = {"model": str(model), "similarity": str(similarity), "softmax_scale": softmax_scale}


### PR DESCRIPTION
Emit DeprecationWarning for features scheduled for removal in v3.0:

- CFLARE estimator: warn on instantiation, fit(), and predict(). Users should migrate to GPCCA.
- GPCCA.fit() / GPCCA.predict(): warn on call. Users should use compute_schur()/compute_macrostates() and predict_terminal_states() directly.
- VelocityKernel model="stochastic"/"monte_carlo": warn when model is not "deterministic". Paves the way for removing the JAX dependency.

All deprecated code paths remain fully functional.

**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
