### PR TITLE
Remove numpy/scipy monkey-patches, bump pygam>=0.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "numba>=0.51,!=0.57",
   "numpy>=1.22",
   "pandas>=1.5",
-  "pygam>=0.8",
+  "pygam>=0.10",
   "pygpcca>=1.0.4",
   "scanpy>=1.7.2",
   "scikit-learn>=1.6",

--- a/src/cellrank/__init__.py
+++ b/src/cellrank/__init__.py
@@ -1,8 +1,5 @@
 from importlib import metadata
 
-import numpy as np
-import scipy.sparse as sp
-
 from cellrank import datasets, estimators, kernels, logging, models, pl
 from cellrank._utils._lineage import Lineage
 from cellrank.settings import settings
@@ -17,9 +14,4 @@ try:
 except ImportError:
     md = None
 
-# pygam uses `.A`
-sp.spmatrix.A = property(lambda self: self.toarray())
-# pygam/utils.py:649: in b_spline_basis
-np.int = int  # noqa: NPY001
-
-del metadata, md, sp, np
+del metadata, md


### PR DESCRIPTION
The monkey-patches in __init__.py were workarounds for pygam < 0.9:
- sp.spmatrix.A: pygam used .A (deprecated scipy alias for .toarray())
- np.int = int: pygam used np.int (removed in numpy 2.0)

Both are fixed in pygam >= 0.9. Remove the patches and bump the lower bound from 0.8 to 0.9.

**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
