### PR TITLE
Fix CellRank-emitted warnings

### DIFF
--- a/src/cellrank/estimators/terminal_states/_gpcca.py
+++ b/src/cellrank/estimators/terminal_states/_gpcca.py
@@ -618,6 +618,7 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
             tsi_df.sort_values(by="number_of_macrostates", inplace=True)
             tsi_df["identified_terminal_states"] = tsi_df["identified_terminal_states"].ffill()
             tsi_df.sort_values(by="number_of_macrostates", ascending=False, inplace=True)
+            tsi_df.index = tsi_df.index.astype(str)
             tsi_df = AnnData(tsi_df, uns={"terminal_states": terminal_states, "cluster_key": cluster_key})
             self._tsi = tsi_df
 

--- a/src/cellrank/models/_base_model.py
+++ b/src/cellrank/models/_base_model.py
@@ -788,18 +788,16 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
 
         if not hide_cells:
             cbar = cbar and (typp == ColorType.CONT)
+            scatter_kwargs: dict[str, Any] = {"s": size, "alpha": alpha}
             if typp == ColorType.CONT:
                 vmin, vmax = _minmax(color, perc)
+                scatter_kwargs.update(cmap=fate_prob_cmap, vmin=vmin, vmax=vmax)
 
             _ = ax.scatter(
                 self.x_all.squeeze(),
                 scaler(self.y_all.squeeze()),
                 c=color,
-                s=size,
-                cmap=fate_prob_cmap,
-                vmin=vmin,
-                vmax=vmax,
-                alpha=alpha,
+                **scatter_kwargs,
             )
 
         if title is None:

--- a/src/cellrank/pl/_log_odds.py
+++ b/src/cellrank/pl/_log_odds.py
@@ -261,6 +261,12 @@ def log_odds(
         else:
             legend = kwargs.get("legend", "auto")
 
+        if palette is None:
+            palette = "dark:black"
+        elif isinstance(palette, list):
+            n_levels = df[hue].nunique()
+            palette = palette[:n_levels]
+
         ax = sns.stripplot(
             x=time_key,
             y="log_odds",
@@ -268,7 +274,6 @@ def log_odds(
             hue=hue,
             order=order,
             jitter=jitter,
-            color="black",
             palette=palette,
             size=size,
             alpha=alpha if alpha is not None else None if thresh_mask is None else 0.8,
@@ -277,6 +282,7 @@ def log_odds(
             **kwargs,
         )
         if thresh_mask is not None:
+            thresh_palette = f"dark:{threshold_color}" if isinstance(palette, str) else palette
             sns.stripplot(
                 x=time_key,
                 y="log_odds",
@@ -284,8 +290,7 @@ def log_odds(
                 hue=hue,
                 order=order,
                 jitter=jitter,
-                color=threshold_color,
-                palette=palette,
+                palette=thresh_palette,
                 size=size * 2,
                 alpha=0.9,
                 ax=ax,


### PR DESCRIPTION
Fix warnings emitted by CellRank's own code. Upstream warnings (scvelo, scanpy, pygam) are left for separate upstream PRs.

## Changes

### `_base_model.py` — "No data for colormapping" (44× per full run)
Only pass `cmap`/`vmin`/`vmax` to `ax.scatter()` when the color type is continuous. Previously these were always passed, triggering matplotlib's `UserWarning: No data for colormapping` when `c` was a string or categorical array.

### `_log_odds.py` — seaborn deprecation warnings (~25×)
- Replace deprecated `color="black"` gradient palette with `palette="dark:black"` (seaborn v0.14 removal)
- Replace `color=threshold_color` with `palette=f"dark:{threshold_color}"`
- Truncate per-point continuous palette lists to number of hue levels, fixing "palette list has more values than needed"

### `_gpcca.py` — `ImplicitModificationWarning` in TSI (2×)
Convert DataFrame index to string before creating AnnData in `tsi()`, preventing anndata's `ImplicitModificationWarning: Transforming to str index`.

## Testing

All 295 plotting tests pass, 89 GPCCA tests pass, 130 model tests pass — verified locally.
