### PR TITLE
test(plotting): make image comparison robust to transparent backgrounds

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -137,6 +137,22 @@ def create_failed_model(adata: AnnData) -> cr.models.FailedModel:
     return cr.models.FailedModel(create_model(adata), exc="foobar")
 
 
+def flatten_onto_white(image_path: str | pathlib.Path) -> None:
+    """Composite an (possibly transparent) image onto an opaque white background, in place.
+
+    CellRank saves figures with a transparent background, so most pixels are fully
+    transparent. :func:`matplotlib.testing.compare.compare_images` keeps the alpha channel
+    whenever an image is not fully opaque and therefore also diffs the *RGB values underneath
+    transparent pixels* -- which are meaningless and whose fill value changed across matplotlib
+    versions. That makes the comparison report huge RMS values even when the visible image is
+    unchanged. Flattening onto white (as e.g. squidpy/scanpy do by saving opaque) makes the
+    comparison depend only on visible pixels.
+    """
+    image = Image.open(image_path).convert("RGBA")
+    background = Image.new("RGBA", image.size, (255, 255, 255, 255))
+    Image.alpha_composite(background, image).convert("RGB").save(image_path)
+
+
 def resize_images_to_same_sizes(
     expected_image_path: str | pathlib.Path,
     actual_image_path: str | pathlib.Path,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,5 +1,7 @@
 import os
 import pathlib
+import shutil
+import tempfile
 from collections.abc import Callable
 from typing import Literal
 
@@ -22,6 +24,7 @@ from cellrank.models import GAMR
 from tests._helpers import (
     create_failed_model,
     create_model,
+    flatten_onto_white,
     gamr_skip,
     resize_images_to_same_sizes,
     scvelo_skip,
@@ -70,7 +73,14 @@ def compare(
 ) -> Callable:
     def _compare_images(expected_path: str | pathlib.Path, actual_path: str | pathlib.Path) -> None:
         resize_images_to_same_sizes(expected_path, actual_path)
-        res = compare_images(expected_path, actual_path, tol=tol)
+        # Flatten transparency so the comparison only sees visible pixels (see
+        # `flatten_onto_white`). The actual image is regenerated each run, so flatten it in
+        # place; copy the committed baseline to a temporary file before flattening it.
+        flatten_onto_white(actual_path)
+        with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
+            shutil.copyfile(expected_path, tmp.name)
+            flatten_onto_white(tmp.name)
+            res = compare_images(tmp.name, actual_path, tol=tol)
         assert res is None, res
 
     def _prepare_fname(func: Callable) -> tuple[str, str]:


### PR DESCRIPTION
## What

Fixes the two stable-CI image failures `tests/test_plotting.py::TestClusterTrends::test_cluster_lineage_raw` and `test_cluster_lineage_2_failed_genes`.

## Why

CellRank saves figures with a **transparent background**, so the vast majority of pixels are fully transparent. `matplotlib.testing.compare.compare_images` keeps the alpha channel whenever an image isn't fully opaque, and therefore also diffs the **RGB values underneath transparent pixels**. Those values are meaningless, and their fill value changed across matplotlib versions — so the comparison reports a huge RMS even when the *visible* image is unchanged.

Measured on `cluster_lineage_raw`: raw RGBA per-channel RMS ≈ 222, but the visible image composited onto white differs by only ≈ 29 (tol 150). The clustering output did **not** meaningfully change; it was transparent-pixel noise.

This is the same failure class behind the large image-test flood in the (non-blocking) pre-release-deps job.

## Fix

Composite both the baseline and the freshly rendered image onto an opaque white background before comparing, so only visible pixels count — the same robustness `squidpy`/`scanpy`/`moscot` get by saving figures opaque. (No scVerse package uses `pytest-mpl`; they all use this `compare_images` harness + a tolerance.)

- The actual image is regenerated each run, so it's flattened in place.
- The committed baseline is copied to a temp file before flattening, so it's never mutated.
- **No baseline regeneration and no test rewrites.**

## Validation

`MPLBACKEND=agg pytest tests/test_plotting.py -n auto` → **306 passed, 9 skipped** locally, including the two previously-failing tests.

> Full stable-CI green also requires #1322 (the anndata `write_basic` fix); these two PRs are independent and together cover all blocking stable failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)