### PR TITLE
fix(cytotrace): handle None layer key in invalid-layer error message

### DIFF
--- a/src/cellrank/kernels/_cytotrace_kernel.py
+++ b/src/cellrank/kernels/_cytotrace_kernel.py
@@ -167,7 +167,9 @@ class CytoTRACEKernel(PseudotimeKernel):
         if layer not in (None, "X") and layer not in self.adata.layers:
             raise KeyError(
                 f"Unable to find `{layer!r}` in `adata.layers`. "
-                f"Valid option are: `{sorted({'X'} | set(self.adata.layers.keys()))}`."
+                # anndata >=0.13 includes ``None`` in ``layers.keys()`` (it aliases ``.X``);
+                # drop it so the set of string options stays sortable.
+                f"Valid option are: `{sorted({'X'} | (set(self.adata.layers.keys()) - {None}))}`."
             )
 
         adata_mraw = self.adata.raw if use_raw else self.adata


### PR DESCRIPTION
## What

Fixes `tests/test_kernels.py::TestCytoTRACEKernel::test_layer[foo]` on the pre-release-deps job (anndata 0.13.0rc1).

## Why

anndata >=0.13 now includes `None` in `adata.layers.keys()` (it aliases `.X`). When an invalid layer is requested, CytoTRACE builds the `KeyError` message via:

```python
sorted({'X'} | set(self.adata.layers.keys()))
```

With `None` now present, sorting a `{str, None}` set raises `TypeError: '<' not supported between instances of 'str' and 'NoneType'` — so the test sees a `TypeError` instead of the expected `KeyError`.

## Fix

Drop `None` from the set before sorting (`"X"` already represents the main matrix in the message). Verified against anndata 0.13.0rc1 in the pre-release env — all `test_layer` params pass.

> Non-blocking job (`continue-on-error`); part of the pre-release-deps cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)