### PR TITLE
test(model): compare ExtensionArray model attrs element-wise

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -214,7 +214,7 @@ def assert_models_equal(
                 assert_array_nan_equal(val2.X, val1.X)
             else:
                 assert val2 is val1, (val2, val1, attr)
-        elif isinstance(val1, (np.ndarray, pd.Series, pd.DataFrame)):
+        elif isinstance(val1, (np.ndarray, pd.Series, pd.DataFrame, pd.api.extensions.ExtensionArray)):
             if deepcopy or pickled:
                 try:
                     assert val2 is not val1, attr


### PR DESCRIPTION
## What

Fixes all 10 `tests/test_model.py::TestModelsIO` tests (pickling/copy/read_write, sklearn + pygam) on the pre-release-deps job.

## Why

Under pre-release deps, `SKLearnModel._obs_names` is a pandas `StringArray` (a `pd.api.extensions.ExtensionArray`) rather than a plain `numpy.ndarray`. The `assert_models_equal` test helper only routed `ndarray`/`Series`/`DataFrame` through its element-wise comparison branch, so `StringArray` fell through to the scalar branch:

```python
assert val2 == val1
```

where `StringArray == StringArray` returns a boolean array → `ValueError: The truth value of an array with more than one element is ambiguous`.

## Fix

Include `pd.api.extensions.ExtensionArray` in the array-comparison branch so such attributes are compared element-wise. Test-only change.

## Validation

`TestModelsIO` → **10 passed** under pre-release deps (anndata 0.13.0rc1 / numpy 2.4.6 / pandas) **and** on the stable env.

> Non-blocking job (`continue-on-error`); part of the pre-release-deps cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)