### PR TITLE
fix(pl): drop deprecated N argument to ListedColormap

### DIFF
--- a/src/cellrank/pl/_cluster_trends.py
+++ b/src/cellrank/pl/_cluster_trends.py
@@ -170,7 +170,7 @@ def cluster_trends(
             for i, colors in enumerate(covariate_colors):
                 ax_clusters = fig.add_subplot(gss[i + 1, 0])
                 if is_color_like(colors[0]):  # e.g. categorical
-                    cm = ListedColormap(colors, N=len(colors))
+                    cm = ListedColormap(list(colors))
                     ax_clusters.imshow(np.arange(cm.N)[None, :], cmap=cm, aspect="auto")
                 else:
                     cm = plt.get_cmap(cmap)


### PR DESCRIPTION
## What

In `cluster_trends`, the per-covariate categorical colormap is built as:

```python
cm = ListedColormap(colors, N=len(colors))
```

Passing `N` to `ListedColormap` is **deprecated since matplotlib 3.11 and will be removed in 3.13** (`MatplotlibDeprecationWarning` at `src/cellrank/pl/_cluster_trends.py:173`).

## Fix

`N` equals the number of colors, so it's redundant — matplotlib defaults `N` to `len(colorlist)`. Drop it:

```python
cm = ListedColormap(list(colors))
```

`cm.N` (used on the next line for `imshow`) and the rendered output are unchanged.

## Validation

- Against **matplotlib 3.11.0rc2** (pre-release env): the `TestClusterTrends` covariate tests pass with the `ListedColormap` deprecation promoted to an error.
- On stable: `TestClusterTrends` → 14 passed (the 2 `cluster_lineage` image-comparison failures are the pre-existing transparent-background issue fixed separately in #1323).

> Independent of the other CI-fix PRs (#1322–#1325); a forward-looking fix so CellRank keeps working on matplotlib ≥3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)