### PR TITLE
fix(deps): replace deprecated numpy.core / scipy.ndimage.filters imports

### DIFF
--- a/src/cellrank/_utils/_lineage.py
+++ b/src/cellrank/_utils/_lineage.py
@@ -167,7 +167,9 @@ def _register_handled_functions():
     # adapted from:
     # https://github.com/numpy/numpy/blob/v1.26.0/numpy/testing/overrides.py#L50
     try:
-        from numpy.core.overrides import ARRAY_FUNCTIONS
+        from numpy.testing.overrides import get_overridable_numpy_array_functions
+
+        ARRAY_FUNCTIONS = get_overridable_numpy_array_functions()
     except ImportError:
         ARRAY_FUNCTIONS = [getattr(np, attr) for attr in dir(np)]
 

--- a/src/cellrank/pl/_heatmap.py
+++ b/src/cellrank/pl/_heatmap.py
@@ -17,7 +17,7 @@ from matplotlib import cm, colors
 from matplotlib.ticker import FormatStrFormatter
 from mpl_toolkits.axes_grid1 import Divider, Size
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
-from scipy.ndimage.filters import convolve
+from scipy.ndimage import convolve
 
 from cellrank._utils import Lineage
 from cellrank._utils._docs import d, inject_docs


### PR DESCRIPTION
## Summary

Both `numpy.core` (renamed to the private `numpy._core`) and `scipy.ndimage.filters` are deprecated and scheduled for removal, so these imports will become hard `ImportError`s on a future NumPy/SciPy release. Surfaced while reproducing CI failures in the pre-release-deps environment.

- **`src/cellrank/_utils/_lineage.py`**: replace `from numpy.core.overrides import ARRAY_FUNCTIONS` with the supported public API `numpy.testing.overrides.get_overridable_numpy_array_functions()`. The fallback path is preserved.
- **`src/cellrank/pl/_heatmap.py`**: import `convolve` from `scipy.ndimage` instead of the deprecated `scipy.ndimage.filters`.

## Verification

- Confirmed the public NumPy API resolves (302 overridable functions) and `scipy.ndimage.convolve` imports in the Python 3.14 env.
- Verified `_register_handled_functions()` produces an equivalent handled set (`np.sum` registered, `np.expand_dims` still excluded).
- `tests/test_lineage.py`: 107 passed.

Closes #1329

🤖 Generated with [Claude Code](https://claude.com/claude-code)