### PR TITLE
docs(install): note PETSc/SLEPc unavailable on Windows conda-forge

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,6 +49,20 @@ To also install PETSc and SLEPc (conda-only packages):
 mamba install -c conda-forge cellrank petsc4py slepc4py
 ```
 
+```{note}
+**Windows users:** [PETSc] and [SLEPc] are not built for Windows on conda-forge
+(only Linux and macOS). Because the conda-forge `cellrank` package depends on
+`pygpcca`, which in turn requires `petsc`, `mamba install -c conda-forge cellrank`
+cannot be solved on Windows and fails with an error such as
+`petsc [...] does not exist (perhaps a missing channel)`.
+
+On Windows, install CellRank with `pip install cellrank` instead. PETSc and SLEPc
+are optional — without them CellRank falls back to a slower [SciPy]-based
+eigensolver for computing macrostates and fate probabilities, which is fine for
+small to medium datasets. To use PETSc and SLEPc on Windows, run CellRank inside
+[WSL] and install via conda there.
+```
+
 ## Development version
 
 To install the latest development version from GitHub:
@@ -62,3 +76,5 @@ See {doc}`contributing` for setting up a full development environment.
 [issue]: https://github.com/theislab/cellrank/issues/new
 [PETSc]: https://petsc.org/
 [SLEPc]: https://slepc.upv.es/
+[SciPy]: https://scipy.org/
+[WSL]: https://learn.microsoft.com/windows/wsl/install


### PR DESCRIPTION
## Problem

Fixes #1269. A Windows user could not `mamba install -c conda-forge cellrank`, failing with:

```
petsc [...] does not exist (perhaps a missing channel)
```

## Root cause

conda-forge builds PETSc (and SLEPc) only for `linux` and `osx`, not Windows (verified via the Anaconda API: `platforms: ['linux', 'osx']`). The conda-forge `cellrank` package depends on `pygpcca`, which hard-requires `petsc`, so the dependency graph is unsolvable on `win-64`. This is an upstream packaging limitation, not a CellRank bug — so the fix is documentation.

## Change

Adds a Windows `{note}` to `docs/installation.md` that:
- explains why the conda install fails on Windows (quoting the exact error),
- directs Windows users to `pip install cellrank` (PETSc/SLEPc are optional; CellRank falls back to a slower SciPy eigensolver),
- points to WSL for users who want PETSc/SLEPc acceleration.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)