### PR TITLE
fix(rtk): recompute transition matrix when conn_weight changes

### DIFF
--- a/src/cellrank/kernels/_real_time_kernel.py
+++ b/src/cellrank/kernels/_real_time_kernel.py
@@ -182,6 +182,7 @@ class RealTimeKernel(UnidirectionalKernel):
         cache_params = dict(kwargs)
         cache_params["threshold"] = threshold
         cache_params["self_transitions"] = str(self_transitions)
+        cache_params["conn_weight"] = conn_weight
         if self._reuse_cache(cache_params):
             return self
 

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1212,6 +1212,27 @@ class TestRealTimeKernel:
             tgt_mask = (tmk.time == tgt).tolist()
             np.testing.assert_allclose(tmat[src_mask, :][:, tgt_mask].toarray(), expected[src, tgt])
 
+    def test_recompute_on_changed_conn_weight(self, adata_large: AnnData):
+        adata_large.obs["time"] = [0] * 50 + [1] * 50 + [2] * 50 + [3] * 50
+        adata_large.obs["time"] = col = adata_large.obs["time"].astype("category")
+        cats = col.cat.categories
+
+        rng = np.random.default_rng(0)
+        couplings = {}
+        for src, tgt in zip(cats[:-1], cats[1:]):
+            n, m = np.sum(col == src), np.sum(col == tgt)
+            couplings[src, tgt] = np.abs(rng.normal(size=(n, m)))
+
+        tmk = RealTimeKernel(adata_large, time_key="time", couplings=couplings)
+        tmk = tmk.compute_transition_matrix(self_transitions="all", conn_weight=0.2, threshold="auto")
+        old = tmk.transition_matrix.copy()
+
+        # changing only `conn_weight` must trigger a recomputation, not reuse the cache
+        tmk = tmk.compute_transition_matrix(self_transitions="all", conn_weight=0.5, threshold="auto")
+
+        assert (tmk.transition_matrix != old).nnz > 0
+        assert tmk.params["conn_weight"] == 0.5
+
     @pytest.mark.parametrize(
         ("problem", "sparse_mode", "policy"),
         [


### PR DESCRIPTION
## Description

`RealTimeKernel.compute_transition_matrix` did not include `conn_weight` in the parameters used to detect cache reuse (`cache_params` only held `threshold` and `self_transitions`). As a result, changing **only** `conn_weight` on an existing kernel object silently returned the stale, already-computed transition matrix instead of recomputing it. `conn_weight` was also missing from `kernel.params`.

This adds `conn_weight` to `cache_params`, so a changed value triggers a recomputation and is correctly recorded in `params`. This matches the reporter's diagnosis in #1271 (manually setting `tmk._params["conn_weight"]` worked around it).

## Changes

- `src/cellrank/kernels/_real_time_kernel.py`: add `conn_weight` to `cache_params`.
- `tests/test_kernels.py`: add `test_recompute_on_changed_conn_weight`, a regression test using explicit couplings (no moscot/wot dependency) asserting the transition matrix changes when only `conn_weight` is altered, and that `params["conn_weight"]` is recorded.

## Testing

`TestRealTimeKernel` passes (8 passed, 5 skipped — moscot/wot/R not installed).

Fixes #1271. Related to #1245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)