### PR TITLE
fix(gpcca): clearer error when no macrostate meets stability threshold

### DIFF
--- a/src/cellrank/estimators/terminal_states/_gpcca.py
+++ b/src/cellrank/estimators/terminal_states/_gpcca.py
@@ -328,6 +328,13 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
                 raise ValueError("Expected `stability_threshold != None` for `method='stability'`.")
             stability = pd.Series(np.diag(coarse_T), index=coarse_T.columns)
             names = stability[stability.values >= stability_threshold].index
+            if not len(names):
+                raise ValueError(
+                    f"No macrostate has a stability `>= {stability_threshold}` "
+                    f"(maximum stability is `{stability.max():.4f}`), so no terminal states could be selected. "
+                    f"Decrease `stability_threshold`, use a different `method` (e.g. `'top_n'`), "
+                    f"or recompute the macrostates with `.compute_macrostates()`."
+                )
             return self.set_terminal_states(
                 names,
                 n_cells=n_cells,

--- a/tests/test_gpcca.py
+++ b/tests/test_gpcca.py
@@ -692,7 +692,7 @@ class TestGPCCA:
         mc.compute_schur(n_components=10, method="krylov")
 
         mc.compute_macrostates(n_states=2)
-        with pytest.raises(ValueError, match=r"No macrostates"):
+        with pytest.raises(ValueError, match=r"No macrostate has a stability"):
             mc.predict(n_cells=5, method="stability", stability_threshold=42)
 
     def test_compute_terminal_states_too_many_cells(self, adata_large: AnnData):


### PR DESCRIPTION
Fixes #1316.

## Problem

`GPCCA.predict_terminal_states()` defaults to `method="stability"` with `stability_threshold=0.96`. The method keeps only macrostates whose self-transition probability (the diagonal of `coarse_T`) is `>= stability_threshold`. When *no* macrostate is that stable, the selection is empty and the call forwards `[]` to `set_terminal_states`, which raised the generic, unhelpful:

```
ValueError: No macrostates have been selected.
```

Several users on #1316 hit this and had no way to tell that the real cause was an overly strict default threshold. (`predict_initial_states()` works for them because it uses the coarse stationary distribution rather than a threshold.)

## Fix

Detect the empty selection in the stability branch *before* delegating, and raise an actionable error that reports the threshold, the actual maximum stability, and concrete remedies:

```
No macrostate has a stability `>= 0.96` (maximum stability is `0.7213`), so no
terminal states could be selected. Decrease `stability_threshold`, use a different
`method` (e.g. `'top_n'`), or recompute the macrostates with `.compute_macrostates()`.
```

The generic message in `set_terminal_states` is left intact — it is still correct for the case where a user explicitly passes an empty selection.

## Test

Updated `test_compute_terminal_states_no_selected` to assert the new, more informative message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)