### PR TITLE
fix(pl): reuse fitted models passed back to gene_trends

### DIFF
--- a/src/cellrank/_utils/_docs.py
+++ b/src/cellrank/_utils/_docs.py
@@ -37,7 +37,9 @@ Nothing, just plots the figure. Optionally saves it based on ``save``."""
 _plots_or_returns_models = """\
 If ``return_models = False``, just plots the figure and optionally saves it based on ``save``.
 Otherwise returns the fitted models as ``{'gene_1': {'lineage_1': <model_11>, ...}, ...}``.
-Models which have failed will be instances of :class:`cellrank.models.FailedModel`."""
+Models which have failed will be instances of :class:`cellrank.models.FailedModel`.
+The returned models can be passed back as ``model`` to reuse the already computed gene trends
+instead of recomputing them."""
 _backward = """\
 backward
     Direction of the process."""

--- a/src/cellrank/pl/_utils.py
+++ b/src/cellrank/pl/_utils.py
@@ -23,7 +23,7 @@ from cellrank._utils._docs import d
 from cellrank._utils._enum import DEFAULT_BACKEND
 from cellrank._utils._parallelize import parallelize
 from cellrank._utils._utils import _unique_order_preserving, save_fig
-from cellrank.models import GAMR, BaseModel, FailedModel, SKLearnModel
+from cellrank.models import GAMR, BaseModel, FailedModel, FittedModel, SKLearnModel
 from cellrank.models._base_model import ColorType
 
 logger = logging.getLogger(__name__)
@@ -60,6 +60,32 @@ def _is_any_gam_mgcv(models: BaseModel | dict[str, dict[str, BaseModel]]) -> boo
     return isinstance(models, GAMR) or (
         isinstance(models, dict) and any(isinstance(m, GAMR) for ms in models.values() for m in ms.values())
     )
+
+
+def _copy_or_reuse_model(model: BaseModel) -> BaseModel:
+    """Copy a gene- and lineage-specific model template, or reuse it if it is already fitted.
+
+    A model that has already been prepared and fitted - e.g. one returned by a plotting function with
+    ``return_models=True`` - is turned into a :class:`~cellrank.models.FittedModel` so that its smoothed
+    values are reused instead of being recomputed. Unfitted models are copied as before, to be fitted afresh.
+
+    This must only be used for models bound to a specific gene *and* lineage; reusing a fitted model that
+    is shared across several lineages (e.g. via a ``'*'`` fallback) would apply one lineage's trend to others.
+
+    Parameters
+    ----------
+    model
+        Model to copy or reuse.
+
+    Returns
+    -------
+    The copied or reused model.
+    """
+    if isinstance(model, FittedModel):
+        return model.copy()
+    if getattr(model, "prepared", False) and model.y_test is not None:
+        return FittedModel.from_model(model)
+    return copy.copy(model)
 
 
 def _create_models(model: _input_model_type, obs: Sequence[str], lineages: Sequence[str | None]) -> _return_model_type:
@@ -104,7 +130,9 @@ def _create_models(model: _input_model_type, obs: Sequence[str], lineages: Seque
                     f"Expected the model for gene `{obs_name!r}` and lineage `{lin_name!r}` "
                     f"to be of type `BaseModel`, found `{type(mod).__name__!r}`."
                 )
-            models[obs_name][lin_name] = copy.copy(mod)
+            # gene- and lineage-specific model: reuse it if already fitted (e.g. returned by a
+            # previous `return_models=True` call), otherwise copy the template to be fit afresh
+            models[obs_name][lin_name] = _copy_or_reuse_model(mod)
 
         if set(models[obs_name].keys()) & lineages == lineages:
             return
@@ -122,6 +150,8 @@ def _create_models(model: _input_model_type, obs: Sequence[str], lineages: Seque
         raise ValueError("No genes have been selected.")
 
     if isinstance(model, BaseModel):
+        # a single model is a template fit afresh for each gene; an already-fitted
+        # `FittedModel` is reused as-is via its `copy`, which preserves the smoothed values
         return {
             o: {lin: copy.copy(model) for lin in _unique_order_preserving(lineages)}
             for o in _unique_order_preserving(obs)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1853,6 +1853,37 @@ class TestGeneTrend:
         np.testing.assert_array_equal(models.columns, [str(i) for i in range(2)])
         assert np.all(models.astype(bool))
 
+    def test_reuse_returned_models(self, adata_cflare: AnnData):
+        model = create_model(adata_cflare)
+        models = cr.pl.gene_trends(
+            adata_cflare,
+            model,
+            GENES[:5],
+            data_key="Ms",
+            lineages=["0", "1"],
+            time_key="latent_time",
+            dpi=DPI,
+            return_models=True,
+        )
+
+        # passing the fitted models back reuses the computed trends instead of refitting
+        reused = cr.pl.gene_trends(
+            adata_cflare,
+            models,
+            GENES[:5],
+            data_key="Ms",
+            lineages=["0", "1"],
+            time_key="latent_time",
+            dpi=DPI,
+            return_models=True,
+        )
+
+        for gene in GENES[:5]:
+            for ln in ["0", "1"]:
+                assert isinstance(reused[gene][ln], cr.models.FittedModel)
+                np.testing.assert_array_equal(reused[gene][ln].x_test, models[gene][ln].x_test)
+                np.testing.assert_array_equal(reused[gene][ln].y_test, models[gene][ln].y_test)
+
     def test_return_models_with_failures(self, adata_cflare: AnnData):
         fm = create_failed_model(adata_cflare)
         models = cr.pl.gene_trends(


### PR DESCRIPTION
## Problem

Closes #1267.

Models returned by `cr.pl.gene_trends(..., return_models=True)` could not be reused. Passing the returned `{gene: {lineage: model}}` dict back as the `model` argument recomputed every trend instead of reusing the fitted values.

**Root cause:** `_create_models` copies each supplied model with `copy.copy`, and a model's `__copy__` deliberately resets the `prepared` flag (models are treated as templates to fit afresh). So `_fit_bulk_helper` re-prepared and re-fit each model from scratch. The only object that survives copying with its fitted data intact is `FittedModel`, but nothing converted the returned `GAM`/`SKLearnModel` objects to that type.

## Fix

Added `_copy_or_reuse_model` in `src/cellrank/pl/_utils.py`: if a model is already prepared and has predicted values (`y_test`), it is wrapped in a `FittedModel` (whose `prepare`/`fit`/`predict` are no-ops returning the stored values); otherwise it is copied as a fresh template, exactly as before.

This is applied **only** to the gene- *and* lineage-specific assignment in `_create_models` — the canonical shape of the returned dict. The `*` fallback and single-model template paths still use plain `copy.copy`, because fanning a fitted model across multiple lineages would wrongly apply one lineage's trend to the others (and a single `FittedModel` already round-trips correctly through `copy.copy`).

The user's expected usage now works:

```python
models = cr.pl.gene_trends(adata, model=model, genes=..., return_models=True, ...)
cr.pl.gene_trends(adata, model=models, genes=..., ...)  # reuses, no refit
```

## Other changes

- Documented the reuse capability in the shared `return_models` docstring (`_docs.py`), which flows into `gene_trends`, `heatmap`, etc.
- Added `test_reuse_returned_models` to `TestGeneTrend` verifying the second call returns `FittedModel` instances with identical `x_test`/`y_test`.

## Verification

- New test plus existing `TestGeneTrend`, `TestHeatmap`, `TestHeatmapReturns`, `TestClusterTrends`, `TestFittedModel` (plotting + model), and `TestCreateModels` all pass.
- pre-commit (ruff check/format) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)