### PR TITLE
test: install moscot in the test dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ test = [
   "coverage[toml]>=7",
   "igraph>=1",
   "jax",
+  "moscot",
   "pillow>=10",
   "pytest>=8",
   "pytest-cov>=6",


### PR DESCRIPTION
## Motivation

`moscot` is declared only as an optional extra (`optional-dependencies.moscot`), not in the `test` dependency group. Both `hatch test` (via `[tool.hatch.envs.hatch-test]` → `test` group) and local `uv sync` (`default-groups = ["dev", "test"]`) draw from that group, so **moscot is never installed during testing — locally or in CI**.

The effect: `TestRealTimeKernel::test_from_moscot*` always skip in CI, so the `RealTimeKernel` optimal-transport path has effectively never been exercised by automated tests. That's plausibly how the caching bug in #1271 went unnoticed.

## Change

Add `moscot` to the `test` dependency group so the `from_moscot` tests run by default. `jax` (moscot's main heavy dependency) is already in the group, and `uv.lock` is unchanged because moscot was already resolved via the existing extra.

## Testing

```
uv lock --check        # lock unchanged / consistent
uv run pytest tests/test_kernels.py::TestRealTimeKernel -k from_moscot
# 4 passed
```

Locally the full `TestRealTimeKernel` suite (with moscot installed) passes 12/13, with only `test_from_wot` still skipped — `wot` is intentionally left out here, as it's unmaintained, ships no Python 3.14 wheel, and needs a from-source C++ build of `POT` that would risk breaking the CI matrix.

Related to #1271 / #1333 (the bug this missing coverage allowed through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)