### PR TITLE
deprecate(rtk): deprecate RealTimeKernel.from_wot (removed in v3)

### DIFF
--- a/src/cellrank/kernels/_real_time_kernel.py
+++ b/src/cellrank/kernels/_real_time_kernel.py
@@ -3,6 +3,7 @@ import logging
 import os
 import pathlib
 import types
+import warnings
 from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -303,6 +304,11 @@ class RealTimeKernel(UnidirectionalKernel):
     ) -> "RealTimeKernel":
         """Construct the kernel from Waddington-OT :cite:`schiebinger:19`.
 
+        .. deprecated:: 2.2
+            Will be removed in CellRank 3.0. Waddington-OT is unmaintained; use :meth:`from_moscot` instead.
+            Pre-computed Waddington-OT couplings can still be loaded manually and passed to
+            :class:`~cellrank.kernels.RealTimeKernel` via the ``couplings`` argument.
+
         Parameters
         ----------
         adata
@@ -334,6 +340,12 @@ class RealTimeKernel(UnidirectionalKernel):
             rtk = cr.kernels.RealTimeKernel.from_wot(adata, path="tmaps/", time_key="day")
             rtk = rtk.compute_transition_matrix()
         """
+        warnings.warn(
+            "`RealTimeKernel.from_wot()` is deprecated and will be removed in CellRank 3.0. "
+            "Use `RealTimeKernel.from_moscot()` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         path = pathlib.Path(path)
         dtype = type(adata.obs[time_key].iloc[0])
 

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1290,7 +1290,8 @@ class TestRealTimeKernel:
         ot_model = wot.ot.OTModel(adata, day_field="exp_time", growth_iters=gr_iters)
         ot_model.compute_all_transport_maps(tmap_out=f"{tmpdir}/")
 
-        tmk = RealTimeKernel.from_wot(adata, path=tmpdir, time_key="exp_time")
+        with pytest.warns(DeprecationWarning, match=r"from_wot.*deprecated"):
+            tmk = RealTimeKernel.from_wot(adata, path=tmpdir, time_key="exp_time")
         obs = pd.read_csv(tmpdir / "tmaps_g.txt", index_col=0, sep="\t")
         tmk = tmk.compute_transition_matrix()
 


### PR DESCRIPTION
## Motivation

Part of slimming the package for CellRank 3.0. `RealTimeKernel.from_wot` is a good candidate to deprecate:

- **Waddington-OT is unmaintained** — no Python 3.14 wheel, and its `POT` dependency needs a fragile from-source C++ build.
- **The path is untested in CI** — `test_from_wot` is `pytest.importorskip("wot")`, so it skips on every CI run; that surface area is effectively unverified.
- **There is a clear, maintained replacement** — `from_moscot` is the actively-developed OT entry point and the one the tutorials/docs use. `from_wot` is not referenced anywhere under `docs/`.
- **No functionality is lost** — `from_wot`'s body has no runtime dependency on `wot` (it just `sc.read`s the per-timepoint coupling `.h5ad` files). Users with pre-computed WOT couplings can keep using them by building the `couplings` dict manually and passing it to `RealTimeKernel(..., couplings=...)`.

This matches the existing v3 deprecation batch (`CFLARE`, `GPCCA.fit`/`predict`, `BaseEstimator.fit`/`predict`, non-deterministic `VelocityKernel` models), all of which use `warnings.warn(..., DeprecationWarning, stacklevel=2)` plus a `.. deprecated::` docstring block.

## Changes

- `from_wot` now emits a `DeprecationWarning` pointing to `from_moscot`, with a `.. deprecated:: 2.2` docstring note describing the manual-couplings migration path.
- `test_from_wot` wraps the call in `pytest.warns(DeprecationWarning, ...)`.

## Testing

Ran the full `from_wot` test end-to-end (with `wot` installed locally), not skipped:

```
uv run pytest tests/test_kernels.py::TestRealTimeKernel::test_from_wot
# 1 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)