### PR TITLE
test: centralize skip markers and enable strict markers/config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,7 @@ lint.pydocstyle.convention = "numpy"
 
 [tool.pytest]
 ini_options.testpaths = "tests"
-ini_options.addopts = [ "--import-mode=importlib" ]
+ini_options.addopts = [ "--import-mode=importlib", "--strict-markers", "--strict-config" ]
 ini_options.xfail_strict = true
 
 [tool.coverage]

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -12,6 +12,7 @@ from PIL import Image
 from sklearn.svm import SVR
 
 import cellrank as cr
+from cellrank._utils._linear_solver import _is_petsc_slepc_available
 from cellrank._utils._utils import _connected
 from cellrank.kernels import ConnectivityKernel, PrecomputedKernel, VelocityKernel
 
@@ -423,6 +424,7 @@ def _create_dummy_adata(n_obs: int) -> AnnData:
 jax_not_installed_skip = pytest.mark.skipif(_jax_not_installed(), reason="JAX is not installed.")
 gamr_skip = pytest.mark.skipif(_rpy2_mgcv_not_installed(), reason="Cannot import `rpy2` or R's `mgcv` package.")
 scvelo_skip = pytest.mark.skipif(_scvelo_not_installed(), reason="scVelo is not installed.")
+petsc_slepc_skip = pytest.mark.skipif(not _is_petsc_slepc_available(), reason="PETSc or SLEPc is not installed.")
 
 if __name__ == "__main__":
     for size in [50, 100, 200]:

--- a/tests/test_gpcca.py
+++ b/tests/test_gpcca.py
@@ -16,7 +16,7 @@ import cellrank as cr
 from cellrank._utils import Lineage
 from cellrank._utils._key import Key
 from cellrank.kernels import ConnectivityKernel, VelocityKernel
-from tests._helpers import assert_array_nan_equal, assert_estimators_equal
+from tests._helpers import assert_array_nan_equal, assert_estimators_equal, petsc_slepc_skip
 
 
 # fmt: off
@@ -1149,11 +1149,9 @@ class TestGPCCAIO:
         with pytest.raises(ValueError, match="Expected `adata` to be of length"):
             _ = cr.estimators.GPCCA.read(os.path.join(tmpdir, "foo.pkl"), adata=adata)
 
+    @petsc_slepc_skip
     @pytest.mark.parametrize("verbose", [None, False])
     def test_compute_schur_verbosity(self, adata_large: AnnData, verbose: bool | None, capsys):
-        _ = pytest.importorskip("petsc4py")
-        _ = pytest.importorskip("slepc4py")
-
         vk = VelocityKernel(adata_large).compute_transition_matrix(softmax_scale=4.0)
         g = cr.estimators.GPCCA(vk)
 

--- a/tests/test_linear_solver.py
+++ b/tests/test_linear_solver.py
@@ -6,12 +6,10 @@ import scipy.sparse as sp
 
 from cellrank._utils._linear_solver import (
     _create_petsc_matrix,
-    _is_petsc_slepc_available,
     _petsc_direct_solve,
     _solve_lin_system,
 )
-
-petsc_slepc_skip = pytest.mark.skipif(not _is_petsc_slepc_available(), reason="PETSc or SLEPc is not installed.")
+from tests._helpers import petsc_slepc_skip
 
 
 def _create_a_b_matrices(seed: int, sparse: bool) -> tuple[np.ndarray, np.ndarray]:


### PR DESCRIPTION
## Motivation

Test-suite hygiene around the skip surface:

- The `petsc_slepc_skip` marker was defined ad-hoc in `test_linear_solver.py`, while the other skip markers (`jax_not_installed_skip`, `gamr_skip`, `scvelo_skip`) live centrally in `tests/_helpers.py`.
- `test_gpcca.py::...::test_compute_schur_verbosity` gated the *same* PETSc/SLEPc dependency via inline `pytest.importorskip(...)` calls — a third, inconsistent way to express the same skip.
- Pytest ran without `--strict-markers`, so a typo'd or unregistered marker would silently pass instead of erroring.

## Changes

- **Centralize `petsc_slepc_skip`** in `tests/_helpers.py` alongside the other skip markers, reusing the production `_is_petsc_slepc_available` helper. `test_linear_solver.py` and `test_gpcca.py` now import it from there.
- **Convert the inline `importorskip`** in `test_compute_schur_verbosity` to the shared `@petsc_slepc_skip` marker, so the whole skip surface is declared in one place.
- **Enable `--strict-markers` and `--strict-config`** in `addopts`. The suite uses only built-in markers (`parametrize`, `skip`), so nothing needs registering — this just guards against future typos/misconfig.

## Testing

```
uv run pytest --collect-only -q          # 1175 tests collected, no marker/config errors
uv run pytest tests/test_linear_solver.py::TestLinearSolverPETSc \
              tests/test_gpcca.py -k "...verbosity" -rs
# 80 skipped via the centralized marker, consistent reason "PETSc or SLEPc is not installed."
```

(PETSc/SLEPc + R run in the dedicated `PETSc / SLEPc + R` CI job; this PR doesn't change which tests run there — only how the skip is declared.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)