### PR TITLE
docs: clarify that PETSc/SLEPc + R tests run in a dedicated CI job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Every fact should have one owner. This file owns invariants and the reference ta
 | Release notes | `docs/release_notes.md` |
 | PR review workflow and risk areas | `REVIEW_GUIDE.md` |
 | Test fixtures | `tests/conftest.py` |
+| CI jobs: test matrix + which extras run where | `.github/workflows/test.yaml` |
 
 ## Module Map
 
@@ -80,4 +81,4 @@ uv run pytest tests/test_kernels.py -v
 uv run pytest tests/test_gpcca.py -v
 ```
 
-PETSc/SLEPc tests are skipped unless the `petsc` extra is installed (requires a working MPI + PETSc/SLEPc build); some R-backed model tests are skipped unless `rpy2` + R's `mgcv` are available. These skips are expected.
+PETSc/SLEPc tests are skipped unless the `petsc` extra is installed (requires a working MPI + PETSc/SLEPc build); some R-backed model tests are skipped unless `rpy2` + R's `mgcv` are available. These skips are expected **locally**, but they are **not** a CI coverage gap: alongside the main `hatch-test` matrix (which skips them), a dedicated `PETSc / SLEPc + R` job in `.github/workflows/test.yaml` installs these stacks and runs the otherwise-skipped tests. Before assuming a skip means "untested in CI", check what that workflow actually installs — the `test` dependency group in `pyproject.toml` is only part of the picture.

--- a/REVIEW_GUIDE.md
+++ b/REVIEW_GUIDE.md
@@ -42,7 +42,7 @@ Flat layout — `tests/test_X.py` keyed by component, not a mirror of `src/`.
 ## Testing
 
 - **New code** should be covered. Reuse fixtures from `tests/conftest.py`; prefer `pytest.mark.parametrize`; favor few meaningful tests over many redundant ones.
-- **Failing CI** is not to be waved through. Distinguish critical regressions from flakes or expected skips (PETSc/SLEPc and R-backed tests skip when the extras are missing); escalate critical failures.
+- **Failing CI** is not to be waved through. Distinguish critical regressions from flakes or expected skips (PETSc/SLEPc and R-backed tests skip in the main matrix when the extras are missing — but they still run in the dedicated `PETSc / SLEPc + R` job in `.github/workflows/test.yaml`, so a *failure* there is real, not an expected skip); escalate critical failures.
 - **Modified tests** — scrutinize *how*. Relaxed tolerances, removed assertions, deleted cases, or loosened matrices are red flags. Require explicit justification in the PR body.
 
 ## Documentation Impact


### PR DESCRIPTION
## Motivation

While auditing skipped tests, I (an agent following `AGENTS.md`) wrongly concluded that the PETSc/SLEPc and R-backed tests *never run in CI*. The cause is the wording in two docs:

- `AGENTS.md`: "*PETSc/SLEPc tests are skipped … R-backed model tests are skipped … These skips are expected.*"
- `REVIEW_GUIDE.md`: "*… expected skips (PETSc/SLEPc and R-backed tests skip when the extras are missing)*"

Both describe the **local** skip behaviour and never mention that CI runs a dedicated **`PETSc / SLEPc + R`** job ([test.yaml](.github/workflows/test.yaml), the `test-conda` job) that conda-installs `petsc slepc petsc4py slepc4py mpi4py rpy2 r-mgcv` and executes exactly those tests. Neither file pointed to the workflow, and the source-of-truth table had no CI row — so the `test` dependency group reads as the whole CI picture.

## Changes

- **`AGENTS.md`**: clarify the skips are expected *locally* but not a CI gap — the dedicated job runs them — and point to `.github/workflows/test.yaml` as the source of truth for what actually runs where. Add a CI row to the "Where To Find What" table (keeping the file's "thin pointer, one owner per fact" style; the workflow remains the owner).
- **`REVIEW_GUIDE.md`**: note that a *failure* in the dedicated job is real, not an expected skip.

No behavioural change; documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)