### PR TITLE
ci(test): upload rendered plotting figures as an artifact

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,6 +78,21 @@ jobs:
       env:
         MPLBACKEND: agg
       run: uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto
+    # Upload the figures the plotting tests rendered so a maintainer can promote
+    # them to ground-truth baselines (see docs/contributing.md). Only the Linux
+    # py3.12-stable job is published: ground-truth figures must match the renderer
+    # CI validates against, and this is the canonical one. `always()` so figures
+    # are available even when an image comparison fails (the actual is saved
+    # before the assertion).
+    - name: Archive rendered figures (ground-truth baseline source)
+      if: always() && matrix.os == 'ubuntu-latest' && matrix.env.name == 'hatch-test.py3.12-stable'
+      uses: actions/upload-artifact@v4
+      with:
+        name: rendered-figures
+        path: tests/figures/*
+        retention-days: 14
+        compression-level: 0  # PNGs are already compressed
+        if-no-files-found: warn
     - name: Generate coverage report
       run: |
         test -f .coverage || uvx hatch run ${{ matrix.env.name }}:cov-combine

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -212,6 +212,48 @@ however the single point of truth for CI jobs is the Hatch test matrix
 defined in `pyproject.toml`. Local testing via hatch and remote CI testing
 use the same Python versions and environments.
 
+(plotting-tests)=
+
+### Plotting tests and ground-truth figures
+
+The plotting tests in `tests/test_plotting.py` come in three flavours, in
+decreasing order of fragility:
+
+- **Visual-regression tests** render a figure and compare it pixel-by-pixel
+  against a committed baseline in `tests/_ground_truth_figures/` (via
+  `matplotlib`'s `compare_images`). Keep these to one representative per
+  plotting function plus genuinely visual variants.
+- **Introspection tests** assert on the returned `Figure`/`Axes` (line width,
+  title text, colormap name, colorbar presence, …) instead of pixels. Prefer
+  these for single-parameter "knob" checks — they are precise and never need a
+  baseline.
+- **Smoke tests** assert that a call runs and returns a `Figure`. Use these for
+  data/behaviour paths that are not worth a pixel baseline.
+
+Only the visual-regression tests need ground-truth figures, so favour the other
+two flavours to keep the baseline set (and the CI fragility it causes on
+dependency bumps) small.
+
+#### Regenerating a ground-truth figure
+
+Pixel rendering differs slightly between operating systems and matplotlib
+versions, so a baseline **must be produced by the same renderer CI validates
+against** — the Linux `hatch-test.py3.12-stable` job. Do **not** commit a figure
+rendered on your laptop (e.g. macOS); it will drift and fail on CI.
+
+CI never updates baselines on its own: every run compares against the committed
+figures and fails on drift. It only *exposes* what it rendered. When you have
+intentionally changed a plot (or are migrating a class to a tighter tolerance):
+
+1. Push your branch and let the `Test` workflow run.
+2. Open the Linux `hatch-test.py3.12-stable` job and download the
+   **`rendered-figures`** artifact (uploaded on every run, pass or fail).
+3. **Review the changed figures** — this is the gate: only promote them if the
+   new output is what you intend.
+4. Copy the relevant PNGs from the artifact into `tests/_ground_truth_figures/`
+   and commit them. The diff (new baseline images) is reviewed like any code.
+5. CI re-runs and now validates against the updated, Linux-matching baselines.
+
 ## Writing documentation
 
 Please write documentation for new or changed features and use-cases.


### PR DESCRIPTION
Foundation for the ongoing plotting-test refactor (#1328): make ground-truth figure regeneration **platform-correct and painless**, so subsequent class migrations can pin a tight tolerance without baseline drift.

## The problem this solves

Pixel baselines must be produced by the same renderer CI validates against (Linux). A figure regenerated on a maintainer's macOS machine drifts and fails CI at a tight tolerance — which is exactly what blocks tightening `STRICT_TOL` on the drift-prone classes. Today nothing exposes the Linux-rendered PNGs, so there's no way to obtain a correct baseline.

## What this does

- Adds an `upload-artifact` step to the `Test` workflow that publishes `tests/figures/*` (where the plotting tests already render) as the **`rendered-figures`** artifact.
- Uploaded from the **Linux `hatch-test.py3.12-stable` job only** — the canonical baseline renderer. Not macOS, not pre-release, not PETSc (we only ever need Linux baselines; also avoids artifact-name collisions and 4× duplication).
- `if: always()` so figures are available even when an image comparison fails (the actual is saved before the assertion) and from passing runs (needed when intentionally tightening tol).
- Bounded: `retention-days: 14`, `compression-level: 0` (PNGs are pre-compressed).
- Documents the regeneration loop + the three plotting-test flavours (visual / introspection / smoke) in `contributing.md`.

## Why this still catches regressions

CI never updates baselines on its own. Every run compares freshly-rendered output against the **committed** figures and fails on drift — that's the regression gate. This PR only makes CI *expose* what it rendered. Promoting an artifact figure to a baseline is a deliberate, human-reviewed commit (like updating a test snapshot). Same model as squidpy / spatialdata-plot.

## Storage footprint

- One run today: ~203 PNGs, **~5–6 MB** (DPI=40; avg ~22 KB each). Shrinks to ~1–2 MB as the refactor reduces image tests.
- Single uploading job + `retention-days: 14` → peak ≈ size × runs-in-window, self-expiring (~tens to low-hundreds of MB, decaying). Public repo; squidpy and spatialdata-plot run the same `always()` upload with **no** retention cap and no issue — this is strictly more conservative.

## Regeneration loop (now documented)

push → CI renders on Linux → download the `rendered-figures` artifact from the `py3.12-stable` job → review the changed figures → copy into `tests/_ground_truth_figures/` → commit → CI validates against the updated, Linux-matching baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)