### PR TITLE
Explain why the coarse stationary distribution is missing in GPCCA

### DIFF
--- a/src/cellrank/estimators/terminal_states/_gpcca.py
+++ b/src/cellrank/estimators/terminal_states/_gpcca.py
@@ -421,7 +421,14 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
 
         stat_dist = self.coarse_stationary_distribution
         if stat_dist is None:
-            raise RuntimeError("No coarse-grained stationary distribution found.")
+            raise RuntimeError(
+                "Unable to predict initial states because no coarse-grained stationary distribution is "
+                "available. It could not be computed because the stationary distribution of the transition "
+                "matrix could not be calculated, which typically happens for very large or (nearly) reducible "
+                "transition matrices where the underlying solver fails to converge. Initial state prediction "
+                "relies on this distribution, so it cannot be done automatically here. Set the initial states "
+                "manually using `.set_initial_states()` instead."
+            )
 
         states = list(stat_dist.iloc[np.argsort(stat_dist)][:n_states].index)
         return self.set_initial_states(states, n_cells=n_cells, allow_overlap=allow_overlap)
@@ -1485,6 +1492,14 @@ class GPCCA(TermStatesEstimator, LinDriversMixin, SchurMixin, EigenMixin):
             init_dist = pd.Series(g.coarse_grained_input_distribution, index=names)
             if g.coarse_grained_stationary_probability is None:
                 stat_dist = None
+                logger.warning(
+                    "Unable to compute the coarse-grained stationary distribution because the stationary "
+                    "distribution of the transition matrix could not be calculated. This typically happens "
+                    "for very large or (nearly) reducible transition matrices, where the underlying solver "
+                    "fails to converge. Automatic initial state prediction via `.predict_initial_states()` "
+                    "will not be available; set the initial states manually using `.set_initial_states()` "
+                    "instead"
+                )
             else:
                 stat_dist = pd.Series(g.coarse_grained_stationary_probability, index=names)
             dists = pd.DataFrame({"coarse_init_dist": init_dist}, index=names)


### PR DESCRIPTION
## What

Improves the diagnostics around the missing coarse-grained stationary distribution in `GPCCA`, without changing behavior.

- **Warn early** at `compute_macrostates` time: as soon as pygpcca returns no stationary probability, a warning explains why it happened and that automatic initial state prediction won't be available.
- **Explain the failure** in `predict_initial_states`: the bare `RuntimeError("No coarse-grained stationary distribution found.")` is replaced with a message that states the root cause and points to `set_initial_states()` as the manual alternative.

## Why

`predict_initial_states` relies on `coarse_stationary_distribution`, which pygpcca sets to `None` whenever the **microstate** stationary distribution of the transition matrix cannot be computed (the solve is wrapped in a `try/except` upstream that warns and returns `None`). This becomes fragile/infeasible on very large or (nearly) reducible transition matrices — exactly the case reported in [#1135](https://github.com/scverse/cellrank/issues/1135), where the failure correlated with dataset size (million-cell runs).

Previously this only surfaced as a bare `RuntimeError` with no explanation. The workaround suggested in that issue thread — passing `predict_initial_states(n_states=...)` — does **not** actually bypass the failing path: the code only skips the stationary distribution when there is exactly one macrostate (`probs.shape[1] == 1`), which is why multiple users reported it didn't help.

## Notes for reviewers

- **No silent fallback.** Initial state prediction deliberately depends on the coarse stationary distribution, so the failure still raises. This PR only makes *why* it failed and *what to do next* clear.
- The two messages are consistent and both steer users to `set_initial_states()`.
- Pure messaging/logging change; no public API or behavior change.

Addresses [#1135](https://github.com/scverse/cellrank/issues/1135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)