### PR TITLE
fix(models): support BaseModel.prepare() with lineage=None when no lineages computed

### DIFF
--- a/src/cellrank/models/_base_model.py
+++ b/src/cellrank/models/_base_model.py
@@ -362,9 +362,8 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
                 f"`adata.X` or `adata.obs`."
             )
 
-        probs = Lineage.from_adata(self.adata, backward=backward)
         if lineage is not None:
-            probs = probs[lineage]
+            probs = Lineage.from_adata(self.adata, backward=backward)[lineage]
 
         if time_key not in self.adata.obs:
             raise KeyError(f"Time key `{time_key!r}` not found in `adata.obs`.")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -107,6 +107,15 @@ class TestModel:
         xtest, xall = model.x_test, model.x_all
         np.testing.assert_allclose(np.r_[xtest[0], xtest[-1]], np.r_[np.min(xall), np.max(xall)])
 
+    def test_prepare_no_lineage(self, adata_cflare):
+        # no lineages computed, `lineage=None` should set all weights to 1 (see #1152)
+        del adata_cflare.obsm[Key.obsm.fate_probs(False)]
+        model = create_model(adata_cflare)
+        model = model.prepare(adata_cflare.var_names[0], None, "latent_time")
+
+        np.testing.assert_array_equal(model.w_all, 1.0)
+        assert model._lineage is None
+
     def test_prepare_resets_fields(self, adata_cflare: AnnData):
         g = GAM(adata_cflare)
 


### PR DESCRIPTION
## Bug fixes

* `BaseModel.prepare()` is documented to set all weights to :math:`1` when `lineage=None`, but it called `Lineage.from_adata()` unconditionally at the top of the method. On an `AnnData` where no fate probabilities had been computed, this raised `KeyError: "Unable to find lineage data in adata.obsm['lineages_fwd']"` before the documented `lineage is None → weights = 1` branch could ever run.
* Fix: move the lineage lookup inside the `lineage is not None` guard. `probs` is only ever read in that branch, so the unconditional call was both unnecessary and the source of the error. Behavior when a lineage *is* requested (including the invalid-lineage `KeyError`) is unchanged.

## Changes

* Added regression test `TestModel::test_prepare_no_lineage` — deletes the fate-probs `obsm` key, calls `prepare(..., lineage=None)`, and asserts `w_all == 1`. It fails against the old code and passes now.

## Related issues

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)