### PR TITLE
docs(kernels): document how to save plot_projection figures

### DIFF
--- a/src/cellrank/kernels/_base_kernel.py
+++ b/src/cellrank/kernels/_base_kernel.py
@@ -284,7 +284,15 @@ class KernelExpression(IOMixin, abc.ABC):
         connectivities
             Connectivity matrix to use for projection. If :obj:`None`, use ones from the underlying kernel, is possible.
         kwargs
-            Keyword argument for the above-mentioned plotting function.
+            Keyword argument for the above-mentioned plotting function. To save the figure, either pass
+            ``save='<name>.pdf'`` (forwarded to :mod:`scvelo`, which writes to its
+            :attr:`~scvelo.settings.figdir` directory, by default ``'./figures/'``), or pass ``show=False`` and use
+            :func:`~matplotlib.pyplot.savefig`::
+
+                import matplotlib.pyplot as plt
+
+                kernel.plot_projection(basis="umap", show=False)
+                plt.savefig("projection.pdf", bbox_inches="tight")
 
         Returns
         -------


### PR DESCRIPTION
## Description

Closes #1171.

`KernelExpression.plot_projection` forwards its `**kwargs` to scvelo's `velocity_embedding_stream` / `velocity_embedding_grid`, so saving a figure works exactly like in scvelo/scanpy — but this was never documented, leading to recurring "how do I save this to PDF?" confusion (and a common false-negative where scvelo's `save=` writes to `./figures/scvelo_<name>.pdf` rather than the path the user typed).

This PR clarifies the `plot_projection` docstring with both options:

- `save='<name>.pdf'` — forwarded to scvelo, which writes to `scv.settings.figdir` (default `./figures/`) with a prefix.
- `show=False` + `matplotlib.pyplot.savefig(...)` — the more reliable approach, saving wherever you want in any format.

Docs-only change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)