### PR TITLE
feat(estimators): add `which="initial_and_terminal"` to plot_macrostates

### DIFF
--- a/src/cellrank/estimators/terminal_states/_term_states_estimator.py
+++ b/src/cellrank/estimators/terminal_states/_term_states_estimator.py
@@ -322,7 +322,7 @@ class TermStatesEstimator(BaseEstimator, abc.ABC):
     @inject_docs(m=PlotMode)
     def plot_macrostates(
         self,
-        which: Literal["all", "initial", "terminal"],
+        which: Literal["all", "initial", "terminal", "initial_and_terminal"],
         states: str | Sequence[str] | None = None,
         color: str | None = None,
         discrete: bool = True,
@@ -344,6 +344,8 @@ class TermStatesEstimator(BaseEstimator, abc.ABC):
             - ``'all'`` - plot all macrostates.
             - ``'initial'`` - plot macrostates marked as :attr:`initial_states`.
             - ``'terminal'`` - plot macrostates marked as :attr:`terminal_states`.
+            - ``'initial_and_terminal'`` - plot both :attr:`initial_states` and :attr:`terminal_states` in one
+              plot. States are renamed to ``'initial: <name>'`` and ``'terminal: <name>'`` to tell them apart.
         states
             Subset of the macrostates to show. If :obj:`None`, plot all macrostates.
         color
@@ -379,12 +381,15 @@ class TermStatesEstimator(BaseEstimator, abc.ABC):
             obj = self._init_states
         elif which == "terminal":
             obj = self._term_states
+        elif which == "initial_and_terminal":
+            obj = self._combine_initial_terminal(discrete=discrete)
         else:
             raise ValueError(
-                f"Unable to plot `{which!r}` states. Valid options are: `{['all', 'initial', 'terminal']}`."
+                f"Unable to plot `{which!r}` states. Valid options are: "
+                f"`{['all', 'initial', 'terminal', 'initial_and_terminal']}`."
             )
 
-        name = "macrostates" if which == "macro" else f"{which} states"
+        name = "initial and terminal states" if which == "initial_and_terminal" else f"{which} states"
         if obj.assignment is None and obj.memberships is None:
             raise RuntimeError(f"Compute {name} first.")
 
@@ -422,6 +427,52 @@ class TermStatesEstimator(BaseEstimator, abc.ABC):
             cmap=cmap,
             **kwargs,
         )
+
+    def _combine_initial_terminal(self, discrete: bool) -> StatesHolder:
+        """Merge :attr:`initial_states` and :attr:`terminal_states` into a single :class:`StatesHolder`.
+
+        States are renamed to ``'initial: <name>'`` / ``'terminal: <name>'`` so they can be told apart in the
+        legend. In the rare case where a cell is assigned to both an initial and a terminal state
+        (only possible with ``allow_overlap=True``), the initial-state assignment takes precedence in discrete mode.
+        """
+        init, term = self._init_states, self._term_states
+        for kind, holder in [("initial", init), ("terminal", term)]:
+            if holder.assignment is None and holder.memberships is None:
+                raise RuntimeError(f"Compute {kind} states first.")
+
+        def _rename(prefix: str, names: Sequence[str]) -> list[str]:
+            return [f"{prefix}: {name}" for name in names]
+
+        assignment = colors = memberships = None
+
+        # discrete representation
+        if init.assignment is not None and term.assignment is not None:
+            init_a, term_a = init.assignment, term.assignment
+            init_cats = _rename("initial", init_a.cat.categories)
+            term_cats = _rename("terminal", term_a.cat.categories)
+            init_r = init_a.cat.rename_categories(dict(zip(init_a.cat.categories, init_cats)))
+            term_r = term_a.cat.rename_categories(dict(zip(term_a.cat.categories, term_cats)))
+            combined = init_r.astype(object).combine_first(term_r.astype(object))
+            assignment = pd.Series(
+                pd.Categorical(combined, categories=init_cats + term_cats),
+                index=init_a.index,
+            )
+            if init.colors is not None and term.colors is not None:
+                colors = np.concatenate([init.colors, term.colors])
+
+        # continuous representation
+        if init.memberships is not None and term.memberships is not None:
+            im, tm = init.memberships, term.memberships
+            memberships = Lineage(
+                np.concatenate([im.X, tm.X], axis=1),
+                names=_rename("initial", im.names) + _rename("terminal", tm.names),
+                colors=list(im.colors) + list(tm.colors),
+            )
+
+        if discrete and assignment is None:
+            raise RuntimeError("Unable to plot initial and terminal states in discrete mode, compute them first.")
+
+        return StatesHolder(assignment=assignment, colors=colors, memberships=memberships)
 
     def _plot_discrete(
         self,

--- a/tests/test_gpcca.py
+++ b/tests/test_gpcca.py
@@ -534,6 +534,50 @@ class TestGPCCA:
         assert len(mc.initial_states.cat.categories) == 3
         assert mc.initial_states_memberships.shape == (adata_large.n_obs, 3)
 
+    @staticmethod
+    def _gpcca_with_initial_and_terminal(adata_large: AnnData) -> "cr.estimators.GPCCA":
+        vk = VelocityKernel(adata_large).compute_transition_matrix(softmax_scale=4)
+        ck = ConnectivityKernel(adata_large).compute_transition_matrix()
+        mc = cr.estimators.GPCCA(0.8 * vk + 0.2 * ck)
+        mc.compute_schur(n_components=10, method="krylov")
+        mc.compute_macrostates(n_states=4, n_cells=5)
+        mc.predict_terminal_states(method="top_n", n_states=2)
+        mc.predict_initial_states(n_states=1, allow_overlap=True)
+        return mc
+
+    def test_combine_initial_terminal_discrete(self, adata_large: AnnData):
+        mc = self._gpcca_with_initial_and_terminal(adata_large)
+
+        combined = mc._combine_initial_terminal(discrete=True)
+        init_cats = [f"initial: {c}" for c in mc.initial_states.cat.categories]
+        term_cats = [f"terminal: {c}" for c in mc.terminal_states.cat.categories]
+
+        np.testing.assert_array_equal(combined.assignment.cat.categories, init_cats + term_cats)
+        assert len(combined.colors) == len(init_cats) + len(term_cats)
+        np.testing.assert_array_equal(combined.memberships.names, init_cats + term_cats)
+
+    def test_combine_initial_terminal_requires_both(self, adata_large: AnnData):
+        vk = VelocityKernel(adata_large).compute_transition_matrix(softmax_scale=4)
+        ck = ConnectivityKernel(adata_large).compute_transition_matrix()
+        mc = cr.estimators.GPCCA(0.8 * vk + 0.2 * ck)
+        mc.compute_schur(n_components=10, method="krylov")
+        mc.compute_macrostates(n_states=4, n_cells=5)
+        mc.predict_terminal_states(method="top_n", n_states=2)
+
+        with pytest.raises(RuntimeError, match="Compute initial states first"):
+            mc.plot_macrostates(which="initial_and_terminal")
+
+    def test_plot_macrostates_invalid_which(self, adata_large: AnnData):
+        mc = self._gpcca_with_initial_and_terminal(adata_large)
+        with pytest.raises(ValueError, match="Unable to plot"):
+            mc.plot_macrostates(which="foobar")
+
+    @pytest.mark.parametrize("discrete", [True, False])
+    @pytest.mark.parametrize("same_plot", [True, False])
+    def test_plot_macrostates_initial_and_terminal(self, adata_large: AnnData, discrete: bool, same_plot: bool):
+        mc = self._gpcca_with_initial_and_terminal(adata_large)
+        mc.plot_macrostates(which="initial_and_terminal", discrete=discrete, same_plot=same_plot)
+
     def test_compute_initial_states_from_forward_normal_run(self, adata_large: AnnData):
         vk = VelocityKernel(adata_large, backward=False).compute_transition_matrix(softmax_scale=4)
         ck = ConnectivityKernel(adata_large).compute_transition_matrix()


### PR DESCRIPTION
## Description

Closes #1005.

Adds a new aggregate plotting mode `which="initial_and_terminal"` to `TermStatesEstimator.plot_macrostates` that shows both initial and terminal macrostates in a single plot. To tell them apart, legend entries are renamed to `initial: <name>` / `terminal: <name>`.

```python
g.plot_macrostates(which="initial_and_terminal")
```

This is the standard discrete plot (top-N cells per macrostate, outlined over a greyed background), now combining both state sets in one view. It also supports `discrete=False` (continuous memberships), `same_plot=True/False`, and the usual kwargs (`legend_loc`, `basis`, `color`, `mode`, …) since it reuses the existing `_plot_discrete` / `_plot_continuous` rendering paths.

### Example (pancreas + PseudotimeKernel)

Initial state `Ngn3 low EP` and terminal states `Alpha`/`Beta`/`Delta`/`Epsilon` in one UMAP, legend prefixed `initial:` / `terminal:`.

## What changed

- `plot_macrostates`: extended the `which` `Literal` and docstring; added dispatch for the new mode and a readable plot title (`"initial and terminal states"`). The existing `which="all"` title behavior is unchanged.
- New helper `_combine_initial_terminal(discrete)` merges the `_init_states` and `_term_states` holders into a single `StatesHolder`:
  - **discrete**: renames each side's categories, merges the categorical assignments, and concatenates colors in category order;
  - **continuous**: concatenates the two membership `Lineage`s with renamed names + concatenated colors;
  - raises a clear `RuntimeError` if either initial or terminal states haven't been computed.
- In the rare `allow_overlap=True` case where a cell belongs to both an initial and a terminal state, the initial assignment takes precedence in discrete mode (a single categorical can't represent both).

## Tests

Added to `tests/test_gpcca.py`:
- structure of the combined holder (categories, colors, membership names),
- the "compute states first" guard,
- the invalid-`which` error,
- a parametrized smoke test over `discrete × same_plot` for the plotting call.

## Notes for reviewers

- No change to the AnnData serialization contract or to existing `which` modes; this is purely additive.
- `_combine_initial_terminal` only merges representations that exist on both sides (assignments for discrete, memberships for continuous), so estimators that don't compute memberships still work in discrete mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)