### PR TITLE
Add Signal API to plot obs/obsm quantities along trajectories (#1202)

### DIFF
--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -20,3 +20,20 @@ and [rpy2](https://rpy2.github.io) installed.
     models.GAMR
     models.SKLearnModel
 ```
+
+## Signals
+
+Signals identify the observation-aligned quantity a model is fit on. Pass them to
+{func}`cellrank.pl.gene_trends` or {meth}`cellrank.models.BaseModel.prepare` to plot gene expression,
+an {attr}`~anndata.AnnData.obs` covariate (e.g. a gene module score), or a column of an
+{attr}`~anndata.AnnData.obsm` array.
+
+```{eval-rst}
+.. autosummary::
+    :toctree: _autosummary/models
+
+    models.Signal
+    models.Gene
+    models.Obs
+    models.Obsm
+```

--- a/src/cellrank/models/__init__.py
+++ b/src/cellrank/models/__init__.py
@@ -1,6 +1,7 @@
 from cellrank.models._base_model import BaseModel, FailedModel, FittedModel
+from cellrank.models._data import Gene, Obs, Obsm, Signal
 from cellrank.models._gamr_model import GAMR
 from cellrank.models._pygam_model import GAM
 from cellrank.models._sklearn_model import SKLearnModel
 
-__all__ = ["BaseModel", "FailedModel", "FittedModel", "GAMR", "GAM", "SKLearnModel"]
+__all__ = ["BaseModel", "FailedModel", "FittedModel", "GAMR", "GAM", "SKLearnModel", "Signal", "Gene", "Obs", "Obsm"]

--- a/src/cellrank/models/_base_model.py
+++ b/src/cellrank/models/_base_model.py
@@ -26,6 +26,7 @@ from cellrank._utils._enum import ModeEnum
 from cellrank._utils._lineage import Lineage
 from cellrank._utils._utils import _densify_squeeze, _minmax, save_fig, valuedispatch
 from cellrank.kernels.mixins import IOMixin
+from cellrank.models._data import _UNSET, Signal, _coerce_signal
 
 logger = logging.getLogger(__name__)
 __all__ = ["BaseModel"]
@@ -176,6 +177,7 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
         self._n_obs = 0 if adata is None else adata.n_obs
         self._model = model
         self._gene = None
+        self._signal = None
         self._use_raw = False
         self._data_key = None
         self._lineage = None
@@ -204,6 +206,11 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
     def prepared(self):
         """Whether the model is prepared for fitting."""
         return self._prepared
+
+    @property
+    def signal(self) -> "Signal | None":
+        """The :class:`~cellrank.models.Signal` this model was prepared with, or :obj:`None`."""
+        return self._signal
 
     @property
     @d.dedent
@@ -296,24 +303,31 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
     @d.dedent
     def prepare(
         self,
-        gene: str,
-        lineage: str | None,
-        time_key: str,
+        signal: "str | Signal" = _UNSET,
+        lineage: str | None = _UNSET,
+        time_key: str = _UNSET,
         backward: bool = False,
         time_range: float | tuple[float, float] | None = None,
-        data_key: str | None = "X",
-        use_raw: bool = False,
+        data_key: str | None = _UNSET,
+        use_raw: bool = _UNSET,
         threshold: float | None = None,
         weight_threshold: float | tuple[float, float] = (0.01, 0.01),
         filter_cells: float | None = None,
         n_test_points: int = 200,
+        *,
+        gene: "str | Signal" = _UNSET,
     ) -> "BaseModel":
         """Prepare the model to be ready for fitting.
 
         Parameters
         ----------
-        gene
-            Gene in :attr:`~anndata.AnnData.var_names`.
+        signal
+            The observation-aligned quantity to fit along the trajectory. Either a
+            :class:`~cellrank.models.Signal` (:class:`~cellrank.models.Gene`, :class:`~cellrank.models.Obs`
+            or :class:`~cellrank.models.Obsm`) or, as a shorthand, a gene name in
+            :attr:`~anndata.AnnData.var_names` (equivalent to :class:`~cellrank.models.Gene`).
+
+            .. versionadded:: 2.3
         lineage
             Name of the lineage. If :obj:`None`, all weights will be set to :math:`1`.
         time_key
@@ -321,10 +335,15 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
         %(backward)s
         %(time_range)s
         data_key
-            Key in :attr:`~anndata.AnnData.layers` or ``'X'`` for :attr:`~anndata.AnnData.X`.
-            If ``use_raw = True``, it's always set to ``'X'``.
+            .. deprecated:: 2.4
+                Pass a :class:`~cellrank.models.Signal` via ``signal`` instead, e.g.
+                ``Gene(name, layer=...)`` or ``Obs(name)``.
         use_raw
-            Whether to access :attr:`~anndata.AnnData.raw`.
+            .. deprecated:: 2.4
+                Pass ``Gene(name, use_raw=True)`` via ``signal`` instead.
+        gene
+            .. deprecated:: 2.4
+                Renamed to ``signal``, which also accepts :class:`~cellrank.models.Signal` objects.
         threshold
             Consider only cells with weights > ``threshold`` when estimating the test endpoint.
             If :obj:`None`, use the median of the weights.
@@ -349,33 +368,22 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
         - :attr:`x_test` - %(base_model_x_test.summary)s
         - :attr:`prepared` - %(base_model_prepared.summary)s
         """
-        if use_raw:
-            if self.adata.raw is None:
-                raise AttributeError("AnnData object has no attribute `.raw`.")
-            if data_key != "X":
-                data_key = "X"
-        self._use_raw = use_raw
+        signal = _coerce_signal(signal, gene=gene, data_key=data_key, use_raw=use_raw)
+        signal.validate(self.adata)
+        self._use_raw = signal.use_raw
+        # the layer (if any) is also used to fetch `cell_color` genes consistently with the trend
+        self._data_key = signal.layer
 
-        if data_key not in ["X", "obs", None] + list(self.adata.layers.keys()):
-            raise KeyError(
-                f"Data key must be a key of `adata.layers`: `{list(self.adata.layers.keys())}`, "
-                f"`adata.X` or `adata.obs`."
-            )
+        if lineage is _UNSET:
+            raise TypeError("Missing the required `lineage` argument.")
+        if time_key is _UNSET:
+            raise TypeError("Missing the required `time_key` argument.")
 
         if lineage is not None:
             probs = Lineage.from_adata(self.adata, backward=backward)[lineage]
 
         if time_key not in self.adata.obs:
             raise KeyError(f"Time key `{time_key!r}` not found in `adata.obs`.")
-
-        if data_key == "obs":
-            if gene not in self.adata.obs:
-                raise KeyError(f"Unable to find data in `adata.obs[{gene!r}]`.")
-        else:
-            if use_raw and gene not in self.adata.raw.var_names:
-                raise KeyError(f"Gene `{gene!r}` not found in `adata.raw.var_names`.")
-            if not use_raw and gene not in self.adata.var_names:
-                raise KeyError(f"Gene `{gene!r}` not found in `adata.var_names`.")
 
         if not isinstance(time_range, (type(None), float, int, tuple)):
             raise TypeError(
@@ -405,21 +413,7 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
         self._obs_names = self.adata.obs_names.values[:]
 
         x = np.array(self.adata.obs[time_key]).astype(self._dtype)
-
-        adata = self.adata.raw.to_adata() if use_raw else self.adata
-        gene_ix = np.where(adata.var_names == gene)[0]
-
-        if data_key in ("X", None):
-            y = adata.X[:, gene_ix]
-            self._data_key = None
-        elif data_key == "obs":
-            y = adata.obs[gene].values
-            # don't set data_key, it's just when `cell_color = ...`
-        elif data_key in adata.layers:
-            y = adata.layers[data_key][:, gene_ix]
-            self._data_key = data_key
-        else:
-            raise NotImplementedError(f"Data key `{data_key!r}` is not implemented.")
+        y = signal.fetch(self.adata, dtype=self._dtype)
 
         if lineage is not None:
             weight_threshold, val = weight_threshold
@@ -427,15 +421,6 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
             w[w < weight_threshold] = val
         else:
             w = np.ones(len(x), dtype=self._dtype)
-
-        if use_raw:
-            correct_ixs = np.isin(self.adata.obs_names, adata.obs_names)
-            x = x[correct_ixs]
-            y = y[correct_ixs]
-            w = w[correct_ixs]
-            self._obs_names = self._obs_names[correct_ixs]
-
-        del adata
 
         self._x_all, self._y_all, self._w_all = (
             _densify_squeeze(x, self._dtype)[:, np.newaxis],
@@ -514,7 +499,8 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
                 f"Values have different shapes: `{self.x.shape[0]}`, `{self.y.shape[0]}`, `{self.w.shape[0]}`."
             )
 
-        self._gene = gene
+        self._gene = signal.name
+        self._signal = signal
         self._lineage = lineage
         self._prepared = True
 
@@ -780,7 +766,7 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
             ),
         )
 
-        if lineage_probability and ylabel in ("expression", self._gene):
+        if lineage_probability and ylabel in ("expression", "value", self._gene):
             ylabel = f"scaled {ylabel}"
 
         vmin, vmax = None, None
@@ -1000,7 +986,7 @@ class BaseModel(IOMixin, abc.ABC, metaclass=BaseModelMeta):
             setattr(dst, attr, copy.copy(getattr(self, attr)))
 
     def _shallowcopy_attributes(self, dst: "BaseModel") -> None:
-        for attr in ["_gene", "_lineage", "_use_raw", "_data_key", "_is_bulk"]:
+        for attr in ["_gene", "_signal", "_lineage", "_use_raw", "_data_key", "_is_bulk"]:
             setattr(dst, attr, copy.copy(getattr(self, attr)))
         # user is not exposed to this
         dst._obs_names = self._obs_names

--- a/src/cellrank/models/_data.py
+++ b/src/cellrank/models/_data.py
@@ -1,0 +1,218 @@
+import abc
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+
+from cellrank._utils._utils import _densify_squeeze
+
+__all__ = ["Signal", "Gene", "Obs", "Obsm"]
+
+#: Sentinel marking a deprecated argument as "not passed" (distinct from a meaningful ``None``).
+_UNSET = object()
+
+
+class Signal(abc.ABC):
+    """Continuous, observation-aligned signal to fit along a trajectory.
+
+    A signal identifies a single 1D quantity defined for every cell -- gene expression
+    (:class:`Gene`), a covariate in :attr:`~anndata.AnnData.obs` (:class:`Obs`), or a column of an
+    :attr:`~anndata.AnnData.obsm` array (:class:`Obsm`). It is the unit consumed by
+    :meth:`~cellrank.models.BaseModel.prepare` and the trajectory plotting functions, replacing the
+    older ``gene`` + ``data_key`` + ``use_raw`` triple.
+    """
+
+    #: Default y-axis label used when the signal name is shown as a title instead.
+    ylabel: str = "value"
+    #: Layer the values are fetched from, if any. Only meaningful for :class:`Gene`.
+    layer: str | None = None
+    #: Whether the values are fetched from :attr:`~anndata.AnnData.raw`. Only meaningful for :class:`Gene`.
+    use_raw: bool = False
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Human-readable name, used for titles, labels and result keys."""
+
+    @abc.abstractmethod
+    def validate(self, adata: AnnData) -> None:
+        """Raise a descriptive error if this signal cannot be fetched from ``adata``."""
+
+    @abc.abstractmethod
+    def _fetch(self, adata: AnnData) -> np.ndarray:
+        """Return the raw, observation-aligned values (possibly sparse or 2D with one column)."""
+
+    def fetch(self, adata: AnnData, *, dtype: np.dtype | type = np.float64) -> np.ndarray:
+        """Return the signal as a dense 1D :class:`~numpy.ndarray` aligned to :attr:`~anndata.AnnData.obs_names`."""
+        self.validate(adata)
+        return _densify_squeeze(self._fetch(adata), dtype)
+
+
+@dataclass(frozen=True)
+class Gene(Signal):
+    """Gene expression signal, fetched from :attr:`~anndata.AnnData.X`, a layer, or :attr:`~anndata.AnnData.raw`.
+
+    Parameters
+    ----------
+    gene
+        Gene in :attr:`~anndata.AnnData.var_names` (or :attr:`~anndata.AnnData.raw` ``.var_names`` when
+        ``use_raw = True``).
+    layer
+        Key in :attr:`~anndata.AnnData.layers` to fetch from. If :obj:`None`, use :attr:`~anndata.AnnData.X`.
+    use_raw
+        Whether to fetch from :attr:`~anndata.AnnData.raw`. Cannot be combined with ``layer``.
+    """
+
+    gene: str
+    layer: str | None = None
+    use_raw: bool = False
+    ylabel = "expression"
+
+    @property
+    def name(self) -> str:  # noqa: D102
+        return self.gene
+
+    def validate(self, adata: AnnData) -> None:  # noqa: D102
+        if self.use_raw and self.layer is not None:
+            raise ValueError(f"Gene `{self.gene!r}`: `use_raw=True` cannot be combined with a layer.")
+        if self.use_raw:
+            if adata.raw is None:
+                raise AttributeError("AnnData object has no attribute `.raw`.")
+            if self.gene not in adata.raw.var_names:
+                raise KeyError(f"Gene `{self.gene!r}` not found in `adata.raw.var_names`.")
+            return
+        if self.gene not in adata.var_names:
+            raise KeyError(f"Gene `{self.gene!r}` not found in `adata.var_names`.")
+        if self.layer is not None and self.layer not in adata.layers:
+            raise KeyError(f"Layer `{self.layer!r}` not found in `adata.layers`.")
+
+    def _fetch(self, adata: AnnData) -> np.ndarray:  # noqa: D102
+        if self.use_raw:
+            raw = adata.raw
+            ix = np.where(raw.var_names == self.gene)[0]
+            return raw.X[:, ix]
+        return adata.obs_vector(self.gene, layer=self.layer)
+
+
+@dataclass(frozen=True)
+class Obs(Signal):
+    """A numeric per-cell covariate stored in :attr:`~anndata.AnnData.obs`, e.g. a gene module score.
+
+    Parameters
+    ----------
+    key
+        Column in :attr:`~anndata.AnnData.obs`.
+    """
+
+    key: str
+
+    @property
+    def name(self) -> str:  # noqa: D102
+        return self.key
+
+    def validate(self, adata: AnnData) -> None:  # noqa: D102
+        if self.key not in adata.obs:
+            raise KeyError(f"Key `{self.key!r}` not found in `adata.obs`.")
+        if not pd.api.types.is_numeric_dtype(adata.obs[self.key]):
+            raise TypeError(
+                f"`adata.obs[{self.key!r}]` must be numeric to be fitted, found dtype `{adata.obs[self.key].dtype}`."
+            )
+
+    def _fetch(self, adata: AnnData) -> np.ndarray:  # noqa: D102
+        return adata.obs[self.key].to_numpy()
+
+
+@dataclass(frozen=True)
+class Obsm(Signal):
+    """A single column of an :attr:`~anndata.AnnData.obsm` array or :class:`~pandas.DataFrame`.
+
+    Parameters
+    ----------
+    key
+        Key in :attr:`~anndata.AnnData.obsm`.
+    column
+        Column to select: an integer position for an array, or a label for a :class:`~pandas.DataFrame`.
+    """
+
+    key: str
+    column: int | str
+
+    @property
+    def name(self) -> str:  # noqa: D102
+        return f"{self.key}[{self.column}]"
+
+    def validate(self, adata: AnnData) -> None:  # noqa: D102
+        if self.key not in adata.obsm:
+            raise KeyError(f"Key `{self.key!r}` not found in `adata.obsm`.")
+        arr = adata.obsm[self.key]
+        if isinstance(arr, pd.DataFrame):
+            if self.column not in arr.columns:
+                raise KeyError(f"Column `{self.column!r}` not found in `adata.obsm[{self.key!r}]` columns.")
+            return
+        arr = np.asarray(arr)
+        if arr.ndim != 2:
+            raise ValueError(f"Expected `adata.obsm[{self.key!r}]` to be 2D, found `{arr.ndim}` dimension(s).")
+        if not isinstance(self.column, (int, np.integer)):
+            raise TypeError(
+                f"`adata.obsm[{self.key!r}]` is an array; `column` must be an integer index, "
+                f"found `{type(self.column).__name__}`."
+            )
+        if not -arr.shape[1] <= self.column < arr.shape[1]:
+            raise IndexError(
+                f"Column index `{self.column}` is out of bounds for `adata.obsm[{self.key!r}]` "
+                f"with `{arr.shape[1]}` column(s)."
+            )
+
+    def _fetch(self, adata: AnnData) -> np.ndarray:  # noqa: D102
+        arr = adata.obsm[self.key]
+        if isinstance(arr, pd.DataFrame):
+            return arr[self.column].to_numpy()
+        return np.asarray(arr)[:, self.column]
+
+
+def _coerce_signal(
+    signal: "str | Signal" = _UNSET,
+    *,
+    gene: "str | Signal" = _UNSET,
+    data_key: str | None = _UNSET,
+    use_raw: bool = _UNSET,
+    warn: bool = True,
+    stacklevel: int = 4,
+) -> Signal:
+    """Resolve a :class:`Signal` from the new ``signal`` argument or the deprecated ``gene``/``data_key``/``use_raw``.
+
+    A :class:`Signal` passed via either ``signal`` or ``gene`` is returned as-is. A bare string ``signal``
+    is the supported shorthand for :class:`Gene` and does not warn. The legacy ``gene``/``data_key``/``use_raw``
+    arguments still work but emit a :class:`DeprecationWarning` and are folded into the equivalent signal.
+    """
+    for candidate in (signal, gene):
+        if isinstance(candidate, Signal):
+            if data_key is not _UNSET or use_raw is not _UNSET:
+                raise TypeError("Cannot combine a `Signal` with the deprecated `data_key`/`use_raw` arguments.")
+            return candidate
+
+    key = signal if signal is not _UNSET else gene
+    if key is _UNSET:
+        raise TypeError("Missing the required `signal` argument (a gene name or a `Gene`/`Obs`/`Obsm`).")
+    if not isinstance(key, str):
+        raise TypeError(f"Expected a `str` gene name or a `Signal`, found `{type(key).__name__}`.")
+
+    if warn and (gene is not _UNSET or data_key is not _UNSET or use_raw is not _UNSET):
+        warnings.warn(
+            "Passing `gene`/`data_key`/`use_raw` will be deprecated in CellRank 2.4 and removed in a later release. "
+            "Pass a `cellrank.models.Gene`, `Obs` or `Obsm` instead, e.g. `Gene('Gata1', layer='Ms')`, "
+            "`Obs('module_score')` or `Obsm('X_pca', 0)`.",
+            DeprecationWarning,
+            stacklevel=stacklevel,
+        )
+
+    dk = None if data_key is _UNSET else data_key
+    if use_raw is not _UNSET and use_raw:
+        return Gene(key, use_raw=True)
+    if dk == "obs":
+        return Obs(key)
+    if dk in (None, "X"):
+        return Gene(key)
+    return Gene(key, layer=dk)

--- a/src/cellrank/pl/_cluster_trends.py
+++ b/src/cellrank/pl/_cluster_trends.py
@@ -17,12 +17,12 @@ from cellrank._utils._docs import d
 from cellrank._utils._enum import DEFAULT_BACKEND, Backend_t
 from cellrank._utils._parallelize import _get_n_cores
 from cellrank._utils._utils import (
-    _check_collection,
     _genesymbols,
     _unique_order_preserving,
     save_fig,
 )
 from cellrank.pl._utils import (
+    _build_gene_signals,
     _callback_type,
     _create_callbacks,
     _create_models,
@@ -183,11 +183,12 @@ def cluster_trends(
 
         return ax if sharey else None
 
-    use_raw = kwargs.get("use_raw", False)
     _ = Lineage.from_adata(adata, backward=backward)[lineage]  # sanity check
 
     genes = _unique_order_preserving(genes)
-    _check_collection(adata, genes, "var_names", use_raw=use_raw)
+    signals = _build_gene_signals(
+        adata, genes, data_key=kwargs.pop("data_key", None), use_raw=kwargs.pop("use_raw", False)
+    )
 
     if key is None:
         key = f"lineage_{lineage}_trend"
@@ -199,12 +200,13 @@ def cluster_trends(
         models = _create_models(model, genes, [lineage])
         all_models, models, genes, _ = _fit_bulk(
             models,
-            _create_callbacks(adata, callback, genes, [lineage], **kwargs),
+            _create_callbacks(adata, callback, genes, [lineage], signals=signals, **kwargs),
             genes,
             lineage,
             time_range,
             return_models=True,  # always return (better error messages)
             filter_all_failed=True,
+            signals=signals,
             parallel_kwargs={
                 "show_progress_bar": show_progress_bar,
                 "n_jobs": _get_n_cores(n_jobs, len(genes)),

--- a/src/cellrank/pl/_gene_trend.py
+++ b/src/cellrank/pl/_gene_trend.py
@@ -1,6 +1,7 @@
 import logging
 import pathlib
 import types
+import warnings
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -16,11 +17,11 @@ from cellrank._utils._docs import d
 from cellrank._utils._enum import DEFAULT_BACKEND, Backend_t
 from cellrank._utils._parallelize import _get_n_cores
 from cellrank._utils._utils import (
-    _check_collection,
     _genesymbols,
     _unique_order_preserving,
     save_fig,
 )
+from cellrank.models._data import _UNSET, Gene, Signal, _coerce_signal
 from cellrank.pl._utils import (
     _callback_type,
     _create_callbacks,
@@ -42,11 +43,11 @@ __all__ = ["gene_trends"]
 def gene_trends(
     adata: AnnData,
     model: _input_model_type,
-    genes: str | Sequence[str],
-    time_key: str,
+    signals: "str | Signal | Sequence[str | Signal]" = _UNSET,
+    time_key: str = _UNSET,
     lineages: str | Sequence[str] | None = None,
     backward: bool = False,
-    data_key: str = "X",
+    data_key: str = _UNSET,
     time_range: _time_range_type | list[_time_range_type] | None = None,
     transpose: bool = False,
     callback: _callback_type = None,
@@ -79,6 +80,7 @@ def gene_trends(
     save: str | pathlib.Path | None = None,
     return_figure: bool = False,
     plot_kwargs: Mapping[str, Any] = types.MappingProxyType({}),
+    genes: "str | Sequence[str]" = _UNSET,
     **kwargs: Any,
 ) -> _return_model_type | None:
     """Plot gene expression trends along lineages.
@@ -88,21 +90,41 @@ def gene_trends(
           visualize the gene trends.
 
     Each lineage is defined via its lineage weights. This function accepts any model based off
-    :class:`~cellrank.models.BaseModel` to fit gene expression, where we take the lineage weights
+    :class:`~cellrank.models.BaseModel` to fit a trend, where we take the lineage weights
     into account in the loss function.
+
+    Beyond gene expression, any observation-aligned quantity that varies continuously along the
+    trajectory can be plotted by passing the appropriate :class:`~cellrank.models.Signal`:
+    :class:`~cellrank.models.Gene` (expression from :attr:`~anndata.AnnData.X`, a layer or
+    :attr:`~anndata.AnnData.raw`), :class:`~cellrank.models.Obs` (a per-cell covariate in
+    :attr:`~anndata.AnnData.obs`, e.g. a gene module score from :func:`~scanpy.tl.score_genes`), or
+    :class:`~cellrank.models.Obsm` (a column of an :attr:`~anndata.AnnData.obsm` array or
+    :class:`~pandas.DataFrame`). Signals of different kinds may be mixed in a single call.
 
     Parameters
     ----------
     %(adata)s
     %(model)s
-    %(genes)s
+    signals
+        What to fit and plot along the trajectory. One or more of:
+
+        - a gene name in :attr:`~anndata.AnnData.var_names` (shorthand for :class:`~cellrank.models.Gene`),
+        - a :class:`~cellrank.models.Gene`, e.g. ``Gene('Gata1', layer='Ms')`` or ``Gene('Gata1', use_raw=True)``,
+        - an :class:`~cellrank.models.Obs`, e.g. ``Obs('module_score')``,
+        - an :class:`~cellrank.models.Obsm`, e.g. ``Obsm('X_pca', 0)`` or ``Obsm('palantir', 'pseudotime')``.
+
+        .. versionadded:: 2.3
     time_key
         Key in :attr:`~anndata.AnnData.obs` where the pseudotime is stored.
     lineages
         Names of the lineages to plot. If :obj:`None`, plot all lineages.
     %(backward)s
     data_key
-        Key in :attr:`~anndata.AnnData.layers` or ``'X'`` for :attr:`~anndata.AnnData.X` where the data is stored.
+        .. deprecated:: 2.4
+            Encode the data source in the signal instead, e.g. ``Gene(name, layer='Ms')`` or ``Obs(name)``.
+    genes
+        .. deprecated:: 2.4
+            Renamed to ``signals``, which also accepts :class:`~cellrank.models.Signal` objects.
     %(time_range)s
         This can also be specified on per-lineage basis.
     %(gene_symbols)s
@@ -170,16 +192,56 @@ def gene_trends(
     -------
     %(plots_or_returns_models)s
     """
-    if isinstance(genes, str):
-        genes = [genes]
-    genes = _unique_order_preserving(genes)
+    # resolve the deprecated `genes` alias
+    if genes is not _UNSET:
+        if signals is not _UNSET:
+            raise TypeError("Got both `signals` and the deprecated `genes`; pass only `signals`.")
+        warnings.warn(
+            "`genes` will be deprecated in CellRank 2.4; use `signals`, which also accepts "
+            "`Gene`/`Obs`/`Obsm` objects.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        signals = genes
+    if signals is _UNSET:
+        raise TypeError("Missing the required `signals` argument.")
+    if time_key is _UNSET:
+        raise TypeError("Missing the required `time_key` argument.")
 
-    _check_collection(
-        adata,
-        genes,
-        "obs" if data_key == "obs" else "var_names",
-        use_raw=kwargs.get("use_raw", False),
-    )
+    # fold the deprecated `data_key`/`use_raw` into bare-string (`Gene`) signals; warn once
+    data_key_legacy = data_key is not _UNSET
+    use_raw_legacy = "use_raw" in kwargs
+    use_raw = kwargs.pop("use_raw", _UNSET)
+    if data_key_legacy or use_raw_legacy:
+        warnings.warn(
+            "`data_key`/`use_raw` will be deprecated in CellRank 2.4; encode the data source in the signal "
+            "instead, e.g. `Gene(name, layer=...)`, `Gene(name, use_raw=True)` or `Obs(name)`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    if isinstance(signals, (str, Signal)):
+        signals = [signals]
+    signal_objs = [
+        s
+        if isinstance(s, Signal)
+        else _coerce_signal(
+            s,
+            data_key=data_key if data_key_legacy else _UNSET,
+            use_raw=use_raw if use_raw_legacy else _UNSET,
+            warn=False,
+        )
+        for s in signals
+    ]
+    signal_objs = _unique_order_preserving(signal_objs)
+    for s in signal_objs:
+        s.validate(adata)
+    names = [s.name for s in signal_objs]
+    if len(set(names)) != len(names):
+        raise ValueError(f"Signals map to duplicate names `{names}`; use distinct sources.")
+    signals_by_name = dict(zip(names, signal_objs))
+    genes = names
+    ylabel_default = "expression" if all(isinstance(s, Gene) for s in signal_objs) else "value"
 
     probs = Lineage.from_adata(adata, backward=backward)
     if lineages is None:
@@ -198,19 +260,19 @@ def gene_trends(
         raise ValueError(f"Expected time ranges to be of length `{len(lineages)}`, found `{len(time_range)}`.")
 
     kwargs["time_key"] = time_key
-    kwargs["data_key"] = data_key
     kwargs["backward"] = backward
     kwargs["conf_int"] = conf_int  # prepare doesnt take or need this
     models = _create_models(model, genes, lineages)
 
     all_models, models, genes, lineages = _fit_bulk(
         models,
-        _create_callbacks(adata, callback, genes, lineages, **kwargs),
+        _create_callbacks(adata, callback, genes, lineages, signals=signals_by_name, **kwargs),
         genes,
         lineages,
         time_range,
         return_models=True,
         filter_all_failed=False,
+        signals=signals_by_name,
         parallel_kwargs={
             "show_progress_bar": show_progress_bar,
             "n_jobs": _get_n_cores(n_jobs, len(genes)),
@@ -308,6 +370,7 @@ def gene_trends(
                 sharey=sharey,
                 gene_as_title=gene_as_title,
                 legend_loc=legend_loc,
+                ylabel_default=ylabel_default,
                 figsize=figsize,
                 fig=fig,
                 axes=axes[row, col] if same_plot else axes[cnt],

--- a/src/cellrank/pl/_heatmap.py
+++ b/src/cellrank/pl/_heatmap.py
@@ -24,7 +24,6 @@ from cellrank._utils._docs import d, inject_docs
 from cellrank._utils._enum import DEFAULT_BACKEND, Backend_t, ModeEnum
 from cellrank._utils._parallelize import _get_n_cores
 from cellrank._utils._utils import (
-    _check_collection,
     _genesymbols,
     _min_max_scale,
     _unique_order_preserving,
@@ -32,6 +31,7 @@ from cellrank._utils._utils import (
     valuedispatch,
 )
 from cellrank.pl._utils import (
+    _build_gene_signals,
     _callback_type,
     _create_callbacks,
     _create_models,
@@ -495,19 +495,22 @@ def heatmap(
     if isinstance(genes, str):
         genes = [genes]
     genes = _unique_order_preserving(genes)
-    _check_collection(adata, genes, "var_names", use_raw=kwargs.get("use_raw", False))
+    signals = _build_gene_signals(
+        adata, genes, data_key=kwargs.pop("data_key", None), use_raw=kwargs.pop("use_raw", False)
+    )
 
     kwargs["backward"] = backward
     kwargs["time_key"] = time_key
     models = _create_models(model, genes, lineages)
     all_models, data, genes, lineages = _fit_bulk(
         models,
-        _create_callbacks(adata, callback, genes, lineages, **kwargs),
+        _create_callbacks(adata, callback, genes, lineages, signals=signals, **kwargs),
         genes,
         lineages,
         time_range,
         return_models=True,  # always return (better error messages)
         filter_all_failed=True,
+        signals=signals,
         parallel_kwargs={
             "show_progress_bar": show_progress_bar,
             "n_jobs": _get_n_cores(n_jobs, len(genes)),

--- a/src/cellrank/pl/_utils.py
+++ b/src/cellrank/pl/_utils.py
@@ -203,6 +203,7 @@ def _fit_bulk_helper[Queue](
     time_range: Sequence[float | tuple[float, float]],
     return_models: bool = False,
     queue: Queue | None = None,
+    signals: Mapping[str, Any] | None = None,
     **kwargs,
 ) -> dict[str, dict[str, BaseModel]]:
     """Fit model for given genes and lineages.
@@ -247,7 +248,10 @@ def _fit_bulk_helper[Queue](
             model = models[gene][ln]
             model._is_bulk = True
 
-            model = cb(model, gene=gene, lineage=ln, time_range=tr, **kwargs)
+            # `signals` maps the (string) result key to the `Signal` actually fetched/fitted;
+            # without it we fall back to passing the bare name (legacy `data_key` path).
+            signal = signals[gene] if signals is not None else gene
+            model = cb(model, gene=signal, lineage=ln, time_range=tr, **kwargs)
             model = model.fit()
             # GAMR is a bit faster if we don't need the conf int
             # if it's needed, `.predict` will calculate it and `confidence_interval` will do nothing
@@ -279,6 +283,7 @@ def _fit_bulk(
     parallel_kwargs: dict,
     return_models: bool = False,
     filter_all_failed: bool = True,
+    signals: Mapping[str, Any] | None = None,
     **kwargs,
 ) -> tuple[_return_model_type, _return_model_type, Sequence[str], Sequence[str]]:
     """Fit models for given genes and lineages.
@@ -331,12 +336,19 @@ def _fit_bulk(
     backend = parallel_kwargs.pop("backend", DEFAULT_BACKEND)
     show_progress_bar = parallel_kwargs.pop("show_progress_bar", True)
 
+    if signals is not None:
+        from cellrank.models._data import Gene
+
+        unit = "gene" if all(isinstance(s, Gene) for s in signals.values()) else "obs"
+    else:
+        unit = "gene" if kwargs.get("data_key", "gene") != "obs" else "obs"
+
     _start = _time.perf_counter()
     logger.info("Computing trends using %d core(s)", n_jobs)
     models = parallelize(
         _fit_bulk_helper,
         genes,
-        unit="gene" if kwargs.get("data_key", "gene") != "obs" else "obs",
+        unit=unit,
         n_jobs=n_jobs,
         backend=backend,
         show_progress_bar=show_progress_bar,
@@ -347,6 +359,7 @@ def _fit_bulk(
         lineages=lineages,
         time_range=time_range,
         return_models=return_models,
+        signals=signals,
         **kwargs,
     )
     logger.info("    Finish (%.2fs)", _time.perf_counter() - _start)
@@ -425,6 +438,7 @@ def _trends_helper(
     gene_as_title: bool = False,
     cell_color: str | None = None,
     legend_loc: str | None = "best",
+    ylabel_default: str = "expression",
     fig: mpl.figure.Figure = None,
     axes: mpl.axes.Axes | Sequence[mpl.axes.Axes] = None,
     **kwargs: Any,
@@ -462,6 +476,9 @@ def _trends_helper(
         Whether to use the gene names as titles (with lineage names as well) or on the y-axis.
     legend_loc
         Location of the legend. If :obj:`None`, don't show any legend.
+    ylabel_default
+        Default y-axis label used when ``gene_as_title = True``. For example, ``'expression'`` for
+        gene expression or ``'value'`` for per-cell values fetched from :attr:`~anndata.AnnData.obs`.
     fig
         Figure to use.
     ax
@@ -566,14 +583,14 @@ def _trends_helper(
         if same_plot:
             if gene_as_title:
                 title = gene
-                ylabel = "expression" if show_ylabel else None
+                ylabel = ylabel_default if show_ylabel else None
             else:
                 title = ""
                 ylabel = gene
         else:
             if gene_as_title:
                 title = None
-                ylabel = "expression" if not ylabel_shown else None
+                ylabel = ylabel_default if not ylabel_shown else None
             else:
                 title = (name if name is not None else "no lineage") if show_lineage[i] else ""
                 ylabel = gene if not ylabel_shown else None
@@ -728,6 +745,7 @@ def _create_callbacks(
     obs: Sequence[str],
     lineages: Sequence[str | None],
     perform_sanity_check: bool | None = None,
+    signals: Mapping[str, Any] | None = None,
     **kwargs,
 ) -> dict[str, dict[str, Callable]]:
     """Create models for each gene and lineage.
@@ -797,13 +815,17 @@ def _create_callbacks(
             for lineage, cb in callbacks[gene].items():
                 # create the model here because the callback can search the attribute
                 dummy_model = SKLearnModel(adata, model=SVR())
+                signal = signals[gene] if signals is not None else gene
+                expected_name = signals[gene].name if signals is not None else gene
                 try:
-                    model = cb(dummy_model, gene=gene, lineage=lineage, **kwargs)
+                    model = cb(dummy_model, gene=signal, lineage=lineage, **kwargs)
                     assert model is dummy_model, (
                         "Creation of new models is not allowed. Ensure that callback returns the same model."
                     )
                     assert model.prepared, "Model is not prepared. Ensure that callback calls `.prepare()`."
-                    assert model._gene == gene, f"Callback modified the gene from `{gene!r}` to `{model._gene!r}`."
+                    assert model._gene == expected_name, (
+                        f"Callback modified the gene from `{expected_name!r}` to `{model._gene!r}`."
+                    )
                     assert model._lineage == lineage, (
                         f"Callback modified the lineage from `{lineage!r}` to `{model._lineage!r}`."
                     )
@@ -888,6 +910,30 @@ def _create_callbacks(
 def _default_model_callback(model: BaseModel, **kwargs) -> BaseModel:
     # we could filter kwargs, but it's better not to - this will detect if we pass useless stuff
     return model.prepare(**kwargs)
+
+
+def _build_gene_signals(
+    adata: AnnData,
+    genes: Sequence[str],
+    *,
+    data_key: str | None = None,
+    use_raw: bool = False,
+) -> dict[str, Any]:
+    """Build and validate a name-keyed mapping of :class:`~cellrank.models.Gene` signals.
+
+    Used by gene-only trajectory plots (``heatmap``, ``cluster_trends``) to fit through the same
+    :class:`~cellrank.models.Signal` machinery as ``gene_trends`` without the deprecated ``data_key``
+    path. ``data_key`` is interpreted as a layer (``None``/``'X'`` meaning :attr:`~anndata.AnnData.X`).
+    """
+    from cellrank.models._data import Gene
+
+    layer = None if data_key in (None, "X") else data_key
+    signals = {}
+    for gene in genes:
+        signal = Gene(gene, layer=layer, use_raw=use_raw)
+        signal.validate(adata)
+        signals[gene] = signal
+    return signals
 
 
 @d.dedent

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,6 +5,7 @@ import pathlib
 import pickle
 
 import numpy as np
+import pandas as pd
 import pytest
 import scipy.stats as st
 from anndata import AnnData
@@ -13,7 +14,7 @@ from sklearn.svm import SVR
 
 from cellrank._utils import Lineage
 from cellrank._utils._key import Key
-from cellrank.models import GAM, GAMR, FittedModel, SKLearnModel
+from cellrank.models import GAM, GAMR, FittedModel, Gene, Obs, Obsm, SKLearnModel
 from cellrank.models._base_model import FailedModel, UnknownModelError
 from cellrank.models._pygam_model import GamDistribution, GamLinkFunction, _gams
 from cellrank.models._utils import (
@@ -829,3 +830,120 @@ class TestFittedModel:
         assert fm.y_all is not m.y_all
         np.testing.assert_array_equal(fm.w_all, m.w_all)
         assert fm.y_all is not m.w_all
+
+
+def _add_signal_data(adata: AnnData) -> AnnData:
+    """Add an obs covariate and obsm arrays (ndarray + DataFrame) used by the signal tests."""
+    import scipy.sparse as sp
+
+    col = adata.X[:, 0]
+    adata.obs["module_score"] = col.toarray().ravel() if sp.issparse(col) else np.asarray(col).ravel()
+    adata.obs["categorical"] = pd.Categorical(["a", "b"] * (adata.n_obs // 2) + ["a"] * (adata.n_obs % 2))
+    block = adata.X[:, :2]
+    adata.obsm["X_emb"] = block.toarray() if sp.issparse(block) else np.asarray(block)
+    adata.obsm["df_emb"] = pd.DataFrame(adata.obsm["X_emb"], columns=["dim1", "dim2"], index=adata.obs_names)
+    return adata
+
+
+class TestSignals:
+    def test_gene_fetches_x(self, adata_cflare):
+        g = adata_cflare.var_names[0]
+        sig = Gene(g)
+        np.testing.assert_array_almost_equal(sig.fetch(adata_cflare), adata_cflare.obs_vector(g))
+        assert sig.name == g
+        assert sig.ylabel == "expression"
+        assert sig.layer is None
+        assert sig.use_raw is False
+
+    def test_gene_fetches_layer(self, adata_cflare):
+        g = adata_cflare.var_names[0]
+        sig = Gene(g, layer="Ms")
+        np.testing.assert_array_almost_equal(sig.fetch(adata_cflare), adata_cflare.obs_vector(g, layer="Ms"))
+        assert sig.layer == "Ms"
+
+    def test_obs_fetches_column(self, adata_cflare):
+        adata = _add_signal_data(adata_cflare)
+        sig = Obs("module_score")
+        np.testing.assert_array_almost_equal(sig.fetch(adata), adata.obs["module_score"].to_numpy())
+        assert sig.name == "module_score"
+        assert sig.ylabel == "value"
+
+    def test_obsm_array_fetches_column(self, adata_cflare):
+        adata = _add_signal_data(adata_cflare)
+        sig = Obsm("X_emb", 1)
+        np.testing.assert_array_almost_equal(sig.fetch(adata), adata.obsm["X_emb"][:, 1])
+        assert sig.name == "X_emb[1]"
+        assert sig.ylabel == "value"
+
+    def test_obsm_dataframe_fetches_column(self, adata_cflare):
+        adata = _add_signal_data(adata_cflare)
+        sig = Obsm("df_emb", "dim2")
+        np.testing.assert_array_almost_equal(sig.fetch(adata), adata.obsm["df_emb"]["dim2"].to_numpy())
+        assert sig.name == "df_emb[dim2]"
+
+    def test_signals_are_hashable(self):
+        assert {Gene("a"), Gene("a"), Obs("a"), Obsm("k", 0)} == {Gene("a"), Obs("a"), Obsm("k", 0)}
+
+    @pytest.mark.parametrize(
+        ("signal", "exc"),
+        [
+            (Gene("not_a_gene"), KeyError),
+            (Gene("g", layer="not_a_layer"), KeyError),
+            (Obs("not_a_col"), KeyError),
+            (Obs("categorical"), TypeError),
+            (Obsm("not_a_key", 0), KeyError),
+            (Obsm("X_emb", 99), IndexError),
+            (Obsm("X_emb", "label"), TypeError),
+        ],
+    )
+    def test_validate_raises(self, adata_cflare, signal, exc):
+        adata = _add_signal_data(adata_cflare)
+        if isinstance(signal, Gene) and signal.gene == "g":
+            signal = Gene(adata.var_names[0], layer="not_a_layer")
+        with pytest.raises(exc):
+            signal.fetch(adata)
+
+
+class TestPrepareSignal:
+    def test_prepare_with_obs_signal(self, adata_cflare):
+        adata = _add_signal_data(adata_cflare)
+        m = create_model(adata).prepare(Obs("module_score"), "0", "latent_time")
+        assert m.prepared
+        assert m._gene == "module_score"
+        assert m.signal == Obs("module_score")
+        assert m._data_key is None
+
+    def test_prepare_with_obsm_signal(self, adata_cflare):
+        adata = _add_signal_data(adata_cflare)
+        m = create_model(adata).prepare(Obsm("X_emb", 1), "0", "latent_time")
+        assert m.prepared
+        assert m._gene == "X_emb[1]"
+
+    def test_prepare_with_gene_layer_signal(self, adata_cflare):
+        g = adata_cflare.var_names[0]
+        m = create_model(adata_cflare).prepare(Gene(g, layer="Ms"), "0", "latent_time")
+        assert m._gene == g
+        assert m._data_key == "Ms"
+
+    def test_bare_string_does_not_warn(self, adata_cflare):
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            create_model(adata_cflare).prepare(adata_cflare.var_names[0], "0", "latent_time")
+
+    @pytest.mark.parametrize("kwargs", [{"data_key": "Ms"}, {"use_raw": False}])
+    def test_legacy_data_key_use_raw_warn(self, adata_cflare, kwargs):
+        g = adata_cflare.var_names[0]
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            create_model(adata_cflare).prepare(g, "0", "latent_time", **kwargs)
+
+    def test_legacy_gene_kwarg_warns(self, adata_cflare):
+        g = adata_cflare.var_names[0]
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            create_model(adata_cflare).prepare(lineage="0", time_key="latent_time", gene=g)
+
+    def test_signal_with_legacy_kwarg_errors(self, adata_cflare):
+        # combining a Signal with data_key is rejected (TypeError, wrapped as a fatal model failure)
+        with pytest.raises(TypeError, match=r"Fatal model"):
+            create_model(adata_cflare).prepare(Gene(adata_cflare.var_names[0]), "0", "latent_time", data_key="Ms")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import shutil
 import tempfile
+import warnings
 from collections.abc import Callable
 from typing import Literal
 
@@ -21,7 +22,7 @@ from cellrank._utils import Lineage
 from cellrank._utils._key import Key
 from cellrank.estimators import CFLARE, GPCCA
 from cellrank.kernels import ConnectivityKernel, PseudotimeKernel, VelocityKernel
-from cellrank.models import GAMR
+from cellrank.models import GAMR, Gene, Obs, Obsm
 from tests._helpers import (
     create_failed_model,
     create_model,
@@ -960,8 +961,15 @@ class TestHeatmapReturns:
 def _run_gene_trends(adata: AnnData, model, genes, **kwargs):
     """Render gene trends and return the :class:`~matplotlib.figure.Figure` for introspection."""
     kwargs.setdefault("time_key", "latent_time")
-    kwargs.setdefault("data_key", "Ms")
-    return cr.pl.gene_trends(adata, model, genes, dpi=DPI, return_figure=True, **kwargs)
+    data_key = kwargs.pop("data_key", "Ms")
+    # exercise the new `Signal` API for the common bare-gene-name case (fit from the `Ms` layer),
+    # falling back to the legacy `data_key` path for raw / gene-symbol cases handled elsewhere
+    gene_list = [genes] if isinstance(genes, str) else genes
+    if not kwargs.get("use_raw", False) and "gene_symbols" not in kwargs and all(isinstance(g, str) for g in gene_list):
+        layer = None if data_key in ("X", None) else data_key
+        signals = [Gene(g, layer=layer) for g in gene_list]
+        return cr.pl.gene_trends(adata, model, signals, dpi=DPI, return_figure=True, **kwargs)
+    return cr.pl.gene_trends(adata, model, genes, dpi=DPI, return_figure=True, data_key=data_key, **kwargs)
 
 
 def _gene_trends_fig(adata: AnnData, **kwargs):
@@ -1267,6 +1275,66 @@ class TestGeneTrend:
         adata, _ = adata_gpcca_fwd
         model, genes, kwargs = setup(adata)
         _assert_drawn(_run_gene_trends(adata, model, genes, **kwargs))
+
+    # --- Signal data paths: plot obs / obsm quantities, not just gene expression ---
+    def _add_signals(self, adata):
+        col = adata.X[:, 0]
+        adata.obs["module_score"] = col.toarray().ravel() if sp.issparse(col) else np.asarray(col).ravel()
+        block = adata.X[:, :2]
+        adata.obsm["X_emb"] = block.toarray() if sp.issparse(block) else np.asarray(block)
+
+    def _signal_trends(self, adata, signals, **kwargs):
+        return cr.pl.gene_trends(
+            adata, create_model(adata), signals, time_key="latent_time", dpi=DPI, return_figure=True, **kwargs
+        )
+
+    def test_trends_obs_signal_runs(self, adata_gpcca_fwd):
+        adata, _ = adata_gpcca_fwd
+        self._add_signals(adata)
+        # not same_plot: the obs column name is used as the y-label
+        fig = self._signal_trends(adata, Obs("module_score"))
+        _assert_drawn(fig)
+        assert any(ax.get_ylabel() == "module_score" for ax in fig.axes)
+
+    def test_trends_obs_signal_neutral_ylabel(self, adata_gpcca_fwd):
+        adata, _ = adata_gpcca_fwd
+        self._add_signals(adata)
+        # same_plot uses the signal name as the title, so the y-label is the neutral "value"
+        fig = self._signal_trends(adata, Obs("module_score"), same_plot=True)
+        ylabels = {ax.get_ylabel() for ax in fig.axes}
+        assert "value" in ylabels
+        assert "expression" not in ylabels
+
+    def test_trends_obsm_signal_runs(self, adata_gpcca_fwd):
+        adata, _ = adata_gpcca_fwd
+        self._add_signals(adata)
+        fig = self._signal_trends(adata, Obsm("X_emb", 1))
+        _assert_drawn(fig)
+        assert any(ax.get_ylabel() == "X_emb[1]" for ax in fig.axes)
+
+    def test_trends_mixed_signals_run(self, adata_gpcca_fwd):
+        adata, _ = adata_gpcca_fwd
+        self._add_signals(adata)
+        fig = self._signal_trends(adata, [adata.var_names[0], Obs("module_score"), Obsm("X_emb", 0)])
+        _assert_drawn(fig)
+        # 3 signals x n_lineages panels
+        assert len(fig.axes) >= 3
+
+    def test_trends_gene_layer_signal_no_warning(self, adata_gpcca_fwd):
+        adata, _ = adata_gpcca_fwd
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            fig = self._signal_trends(adata, Gene(adata.var_names[0], layer="Ms"))
+        _assert_drawn(fig)
+
+    def test_trends_deprecated_genes_and_data_key_warn(self, adata_gpcca_fwd):
+        adata, _ = adata_gpcca_fwd
+        with pytest.warns(DeprecationWarning, match="`genes` will be deprecated"):
+            cr.pl.gene_trends(adata, create_model(adata), genes=GENES[0], time_key="latent_time", return_figure=True)
+        with pytest.warns(DeprecationWarning, match="`data_key`/`use_raw` will be deprecated"):
+            cr.pl.gene_trends(
+                adata, create_model(adata), GENES[0], time_key="latent_time", data_key="Ms", return_figure=True
+            )
 
     # --- behavior / error contracts ---
     def test_invalid_time_key(self, adata_cflare: AnnData):


### PR DESCRIPTION
## Summary

Closes #1202. Adds a `Signal` abstraction so trajectory plots can fit **any observation-aligned quantity that varies continuously along pseudotime** — not just gene expression. This covers the original request (plot a precomputed gene module score) and generalizes it to `.X`/layers/`.raw`, `.obs` covariates, and `.obsm` columns.

The motivation: "which obs-aligned signal to fit" was previously smeared across three loosely-coupled parameters (`gene` + `data_key` + `use_raw`), which is why `.obsm` couldn't be expressed and `data_key` was ambiguous. A `Signal` makes it **one self-describing value**.

## New public API (`cellrank.models`)

```python
from cellrank.models import Gene, Obs, Obsm

cr.pl.gene_trends(adata, model, "Gata1")                     # str -> Gene from .X (shorthand)
cr.pl.gene_trends(adata, model, Gene("Gata1", layer="Ms"))   # a layer
cr.pl.gene_trends(adata, model, Gene("Gata1", use_raw=True)) # raw
cr.pl.gene_trends(adata, model, Obs("module_score"))         # an .obs covariate / module score
cr.pl.gene_trends(adata, model, Obsm("X_pca", 0))            # .obsm array column
cr.pl.gene_trends(adata, model, Obsm("palantir", "pt"))      # .obsm DataFrame column
cr.pl.gene_trends(adata, model, ["Gata1", Obs("module_score")])  # mix freely
```

Each `Signal` is a frozen dataclass owning its own `fetch`/`validate`/`name`/`ylabel`; adding a new source is a new subclass with no signature churn.

## Changes

- **`Signal`/`Gene`/`Obs`/`Obsm`** — new module `src/cellrank/models/_data.py`, exported from `cellrank.models`, documented in `docs/api/models.md`.
- **`BaseModel.prepare(signal, ...)`** — fetch branching collapses to `signal.fetch(adata)`; new `.signal` property.
- **`gene_trends`** — `genes` → `signals` (accepts `Signal`s or bare names); per-figure neutral y-label (`"value"`) for non-gene signals; per-signal validation.
- **Fan-out** (`_create_callbacks`/`_fit_bulk`) threads a `signals` map to `prepare`; **`heatmap`/`cluster_trends`** route through the same machinery (no public change, no internal warnings).

## Backward compatibility

The legacy `gene`/`data_key`/`use_raw` (on `prepare`) and `genes`/`data_key`/`use_raw` (on `gene_trends`) still work, folded into the equivalent `Signal`. Bare gene-name strings are unchanged and warning-free.

Versioning per the 2.3 → 2.4 plan:
- New API marked `.. versionadded:: 2.3`.
- Legacy params emit a `DeprecationWarning` reading **"will be deprecated in CellRank 2.4"**; `.. deprecated:: 2.4` directives are in place for the formal 2.4 deprecation.

## Tests

- `TestSignals` + `TestPrepareSignal` (21 tests): fetch/validate/name/ylabel for all three sources, `prepare` with each, deprecation warnings, error contracts.
- New `gene_trends` tests for Obs/Obsm/mixed/neutral-ylabel + deprecation-path coverage; existing smoke tests migrated onto the `Gene` API.
- **463 passed, 21 skipped** across `test_plotting`/`test_model`/`test_utils`; `pre-commit` (ruff check + format) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)