### PR TITLE
test(plotting): replace bilinear-resize fallback; fix dpi propagation (#1327)

### DIFF
--- a/src/cellrank/_utils/_utils.py
+++ b/src/cellrank/_utils/_utils.py
@@ -884,7 +884,7 @@ def _maybe_create_dir(dirpath: str | os.PathLike) -> None:
             os.makedirs(dirpath, exist_ok=True)
 
 
-def save_fig(fig, path: str | os.PathLike, make_dir: bool = True, ext: str = "png") -> None:
+def save_fig(fig, path: str | os.PathLike, make_dir: bool = True, ext: str = "png", dpi: float | None = None) -> None:
     """Save a plot.
 
     Parameters
@@ -897,6 +897,10 @@ def save_fig(fig, path: str | os.PathLike, make_dir: bool = True, ext: str = "pn
         Whether to try making the directory if it does not exist.
     ext
         Extension to use.
+    dpi
+        Resolution in dots per inch. If :obj:`None`, the figure's own dpi is used. Pass this for
+        figures created by ``sc.pl.embedding`` and friends, which build the figure at scanpy's
+        default dpi and ignore a requested ``dpi`` -- the size is only honored here, at save time.
 
     Returns
     -------
@@ -915,7 +919,7 @@ def save_fig(fig, path: str | os.PathLike, make_dir: bool = True, ext: str = "pn
 
     logger.debug("Saving figure to %r", path)
 
-    fig.savefig(path, bbox_inches="tight", transparent=True)
+    fig.savefig(path, bbox_inches="tight", transparent=True, dpi=dpi)
 
 
 def _convert_to_categorical_series(

--- a/src/cellrank/estimators/terminal_states/_term_states_estimator.py
+++ b/src/cellrank/estimators/terminal_states/_term_states_estimator.py
@@ -517,7 +517,8 @@ class TermStatesEstimator(BaseEstimator, abc.ABC):
         if kwargs.get("legend_loc") == "right":
             kwargs["legend_loc"] = "right margin"
         kwargs.pop("color_map", None)
-        kwargs.pop("dpi", None)  # handled at figure level, not by sc.pl.embedding
+        # `sc.pl.embedding` ignores `dpi`; forward it to `save_fig`, which honors it at save time.
+        dpi = kwargs.pop("dpi", None)
         save = kwargs.pop("save", None)
         show = kwargs.pop("show", None)
         kwargs["cmap"] = cmap
@@ -573,7 +574,7 @@ class TermStatesEstimator(BaseEstimator, abc.ABC):
                         ax.set_title(ax_title)
 
         if save is not None:
-            save_fig(plt.gcf(), save)
+            save_fig(plt.gcf(), save, dpi=dpi)
         if show is True or (show is None and save is None):
             plt.show()
         # fmt: on
@@ -661,7 +662,8 @@ class TermStatesEstimator(BaseEstimator, abc.ABC):
                 _plot_color_gradients(self.adata, _data, basis=basis, title=title,
                                       save=save, show=show, **kwargs)
             else:
-                kwargs.pop("dpi", None)  # handled at figure level, not by sc.pl.embedding
+                # `sc.pl.embedding` ignores `dpi`; forward it to `save_fig`, which honors it at save time.
+                dpi = kwargs.pop("dpi", None)
                 title = [f"{_title} {state}" for state in states] if title is None else title
                 if isinstance(title, str):
                     title = [title]
@@ -675,7 +677,7 @@ class TermStatesEstimator(BaseEstimator, abc.ABC):
                         title=title, cmap=cmap, show=False, **kwargs,
                     )
                 if save is not None:
-                    save_fig(plt.gcf(), save)
+                    save_fig(plt.gcf(), save, dpi=dpi)
                 if show is True or (show is None and save is None):
                     plt.show()
         else:

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -154,27 +154,62 @@ def flatten_onto_white(image_path: str | pathlib.Path) -> None:
     Image.alpha_composite(background, image).convert("RGB").save(image_path)
 
 
-def resize_images_to_same_sizes(
+# Relative size tolerance for image comparisons. Sub-pixel `bbox_inches="tight"` rounding drifts
+# the rendered pixel size by a few px across platforms (Linux CI baseline vs local dev) and
+# matplotlib versions; anything beyond this is a gross layout/DPI/backend divergence we want to
+# surface rather than absorb. This is the size-axis analogue of the RMS `STRICT_TOL`.
+SIZE_RTOL = 0.1
+
+
+def assert_image_sizes_close(
     expected_image_path: str | pathlib.Path,
     actual_image_path: str | pathlib.Path,
-    kind: str = "actual_to_expected",
+    *,
+    rtol: float = SIZE_RTOL,
 ) -> None:
+    """Fail when the rendered image grossly diverges in pixel size from the committed baseline.
+
+    Replaces the old bilinear-resize fallback, which silently squashed the rendered image to the
+    baseline size before comparison -- that both masked real regressions (a genuinely different
+    layout squashed to match) and manufactured fake diffs (interpolation blurs the image before the
+    RMS comparison). We instead fail loudly on a gross size mismatch and otherwise leave the pixels
+    untouched; small cross-platform / matplotlib-version drift in the ``bbox_inches="tight"`` crop
+    is absorbed by ``rtol`` and the caller compares on the common (cropped, non-interpolated)
+    region.
+    """
     if not os.path.isfile(actual_image_path):
         raise OSError(f"Actual image path `{actual_image_path!r}` does not exist.")
     if not os.path.isfile(expected_image_path):
         raise OSError(f"Expected image path `{expected_image_path!r}` does not exist.")
-    expected_image = Image.open(expected_image_path)
-    actual_image = Image.open(actual_image_path)
-    if expected_image.size != actual_image.size:
-        if kind == "actual_to_expected":
-            actual_image.resize(expected_image.size).save(actual_image_path)
-        elif kind == "expected_to_actual":
-            expected_image.resize(actual_image.size).save(expected_image)
-        else:
-            raise ValueError(
-                f"Invalid kind of conversion `{kind!r}`."
-                f"Valid options are `'actual_to_expected'`, `'expected_to_actual'`."
-            )
+    (ew, eh), (aw, ah) = Image.open(expected_image_path).size, Image.open(actual_image_path).size
+    ratio = max(aw / ew, ew / aw, ah / eh, eh / ah)
+    assert ratio <= 1 + rtol, (
+        f"Rendered image size {(aw, ah)} diverges from baseline size {(ew, eh)} by "
+        f"{(ratio - 1) * 100:.0f}% (> {rtol * 100:.0f}% tolerance) "
+        f"(`{actual_image_path}` vs `{expected_image_path}`). This signals a change in "
+        f"matplotlib, layout, DPI, or backend; fix the root cause or regenerate the baseline."
+    )
+
+
+def crop_images_to_common_size(
+    image_path_a: str | pathlib.Path,
+    image_path_b: str | pathlib.Path,
+) -> None:
+    """Crop both images in place to their common (minimum) size, top-left aligned.
+
+    :func:`matplotlib.testing.compare.compare_images` requires identical dimensions. Unlike the old
+    resize, cropping does not interpolate, so it neither blurs the image nor manufactures diffs; a
+    genuine layout change still shows up in the overlapping region's RMS. Only meaningful once the
+    sizes are already known to be close (see :func:`assert_image_sizes_close`).
+    """
+    image_a, image_b = Image.open(image_path_a), Image.open(image_path_b)
+    width = min(image_a.width, image_b.width)
+    height = min(image_a.height, image_b.height)
+    box = (0, 0, width, height)
+    if image_a.size != (width, height):
+        image_a.crop(box).save(image_path_a)
+    if image_b.size != (width, height):
+        image_b.crop(box).save(image_path_b)
 
 
 def assert_array_nan_equal(actual: np.ndarray | pd.Series, expected: np.ndarray | pd.Series) -> None:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -23,11 +23,12 @@ from cellrank.estimators import CFLARE, GPCCA
 from cellrank.kernels import ConnectivityKernel, PseudotimeKernel, VelocityKernel
 from cellrank.models import GAMR
 from tests._helpers import (
+    assert_image_sizes_close,
     create_failed_model,
     create_model,
+    crop_images_to_common_size,
     flatten_onto_white,
     gamr_skip,
-    resize_images_to_same_sizes,
     scvelo_skip,
 )
 
@@ -44,6 +45,13 @@ DPI = 40
 # image tests; the default should drop to `STRICT_TOL` once every class has been migrated.
 TOL = 150
 STRICT_TOL = 50
+
+# Baselines that the resize fallback used to mask (see #1327): removing the bilinear resize exposed
+# that these committed figures are stale. The macrostate-scatter baselines predate the #1302
+# scvelo->scanpy switch (content drift, ~69 RMS), and the projection / macrostate-composition ones
+# predate later layout/figsize changes. `strict=False` so they still pass once regenerated on CI.
+_STALE_SCATTER_BASELINE = "stale scvelo->scanpy macrostate-scatter baseline; regenerate on CI (#1328)"
+_STALE_LAYOUT_BASELINE = "stale baseline after layout/figsize change; regenerate on CI (#1328)"
 
 # both are for `50` adata
 GENES = [
@@ -79,7 +87,9 @@ def compare(
     tol: int = TOL,
 ) -> Callable:
     def _compare_images(expected_path: str | pathlib.Path, actual_path: str | pathlib.Path) -> None:
-        resize_images_to_same_sizes(expected_path, actual_path)
+        # Fail loudly on a gross size mismatch (real layout/DPI/backend change) instead of the old
+        # bilinear-resize fallback, which masked regressions and manufactured fake diffs.
+        assert_image_sizes_close(expected_path, actual_path)
         # Flatten transparency so the comparison only sees visible pixels (see
         # `flatten_onto_white`). The actual image is regenerated each run, so flatten it in
         # place; copy the committed baseline to a temporary file before flattening it.
@@ -87,6 +97,9 @@ def compare(
         with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
             shutil.copyfile(expected_path, tmp.name)
             flatten_onto_white(tmp.name)
+            # `compare_images` requires identical dimensions; crop (no interpolation) to absorb the
+            # sub-pixel size drift left within `assert_image_sizes_close`'s tolerance.
+            crop_images_to_common_size(tmp.name, actual_path)
             res = compare_images(tmp.name, actual_path, tol=tol)
         assert res is None, res
 
@@ -1442,22 +1455,27 @@ class TestGPCCA:
     def test_gpcca_coarse_T_stat_init_dist(self, mc: GPCCA, fpath: str):
         mc.plot_coarse_T(show_initial_dist=True, show_stationary_dist=True, dpi=DPI, save=fpath)
 
+    @pytest.mark.xfail(reason=_STALE_SCATTER_BASELINE, strict=False)
     @compare(kind="gpcca", tol=STRICT_TOL)
     def test_gpcca_meta_states(self, mc: GPCCA, fpath: str):
         mc.plot_macrostates(which="all", dpi=DPI, save=fpath)
 
+    @pytest.mark.xfail(reason=_STALE_SCATTER_BASELINE, strict=False)
     @compare(kind="gpcca", tol=STRICT_TOL)
     def test_gpcca_meta_states_discrete(self, mc: GPCCA, fpath: str):
         mc.plot_macrostates(which="all", discrete=True, dpi=DPI, save=fpath)
 
+    @pytest.mark.xfail(reason=_STALE_SCATTER_BASELINE, strict=False)
     @compare(kind="gpcca", tol=STRICT_TOL)
     def test_gpcca_meta_states_no_same_plot(self, mc: GPCCA, fpath: str):
         mc.plot_macrostates(which="all", same_plot=False, dpi=DPI, save=fpath)
 
+    @pytest.mark.xfail(reason=_STALE_SCATTER_BASELINE, strict=False)
     @compare(kind="gpcca", tol=STRICT_TOL)
     def test_gpcca_meta_states_time(self, mc: GPCCA, fpath: str):
         mc.plot_macrostates(which="all", mode="time", dpi=DPI, save=fpath)
 
+    @pytest.mark.xfail(reason=_STALE_SCATTER_BASELINE, strict=False)
     @compare(kind="gpcca", tol=STRICT_TOL)
     def test_gpcca_final_states(self, mc: GPCCA, fpath: str):
         mc.plot_macrostates(which="terminal", dpi=DPI, save=fpath)
@@ -1926,6 +1944,7 @@ class TestCircularProjection:
         plt.close("all")
 
     # --- visual regression: canonical categorical projection ---
+    @pytest.mark.xfail(reason=_STALE_LAYOUT_BASELINE, strict=False)
     @compare(tol=STRICT_TOL)
     def test_proj_default_ordering(self, adata: AnnData, fpath: str):
         cr.pl.circular_projection(adata, keys="clusters", lineage_order="default", dpi=DPI, save=fpath)
@@ -2344,6 +2363,7 @@ def _msc_obsm_weighted(g):
 
 class TestMacrostateComposition:
     # --- visual regression: the stacked-bar baseline ---
+    @pytest.mark.xfail(reason=_STALE_LAYOUT_BASELINE, strict=False)
     @compare(kind="gpcca", tol=STRICT_TOL)
     def test_msc_default(self, mc: GPCCA, fpath: str):
         mc.plot_macrostate_composition("clusters", dpi=DPI, save=fpath)


### PR DESCRIPTION
Closes #1327.

## Problem

`tests/_helpers.py::resize_images_to_same_sizes` ran before every `compare_images`, **bilinearly resizing the rendered figure to the baseline's pixel size** whenever they differed. A size mismatch is itself a signal that something changed (matplotlib/layout/DPI/backend), and resizing both:
- **masked real regressions** — a genuinely different layout was squashed to match, then passed under the RMS tolerance, and
- **manufactured fake diffs** — interpolation blurs the image before the RMS comparison.

## What changed

### 1. Harness: resize fallback → size tolerance + crop
*(`tests/_helpers.py`, `tests/test_plotting.py`)*

- Remove `resize_images_to_same_sizes`.
- Add `assert_image_sizes_close` — a relative size tolerance (`SIZE_RTOL = 0.1`, the size-axis analogue of `STRICT_TOL`): fail loudly on gross size divergence, absorb sub-pixel `bbox_inches="tight"` rounding drift across platforms / matplotlib versions.
- Add `crop_images_to_common_size` — crop (no interpolation) so `compare_images` gets identical dimensions without blurring. The RMS comparison then runs on real, non-interpolated pixels.

This is consistent with #1328's philosophy (robustness via low DPI + tolerance, not pinning) rather than a strict size equality, which would flag ~17 sub-pixel-jitter tests — including baselines #1328 just regenerated.

### 2. dpi propagation fix
*(`src/cellrank/_utils/_utils.py`, `src/cellrank/estimators/terminal_states/_term_states_estimator.py`)*

Removing the resize exposed that `plot_macrostates` rendered **~2.6× too large**: `_plot_discrete` and the `_plot_continuous` non-same-plot branch popped `dpi` and **discarded** it (the `# handled at figure level` comment was never implemented), so `sc.pl.embedding` rendered at scanpy's default ~100 dpi instead of the requested 40.

`save_fig` now accepts an optional `dpi` forwarded to `fig.savefig`, and both embedding paths pass it through. This restores baseline-matching resolution and recovers `test_final_states` / `test_lin_probs` (which now pass). The new param is backward-compatible — all existing callers behave identically.

## Stale baselines (7 `xfail`)

Removing the resize surfaced 7 committed baselines it had been masking. They are genuinely stale and need regenerating on **Linux CI** (they can't be reliably regenerated on macOS — font metrics shift the `tight` bbox). They're marked `xfail(strict=False)` with reasons so they're **tracked, not masked**, and pass without XPASS errors once regenerated:

- **5 GPCCA macrostate-scatter** (`test_gpcca_meta_states*`, `test_gpcca_final_states`) — scvelo→scanpy content drift (#1302, ~69 RMS). The size half is now fixed by the dpi change; the content half remains.
- **`test_proj_default_ordering`, `test_msc_default`** — later layout/figsize changes.

## Coordination with #1328

These 7 should be regenerated and un-`xfail`ed as part of #1328 (they are the canonical visual-regression tests #1328 keeps, not knob tests it converts). **Ordering matters:** the dpi fix must be in the tree *before* those macrostate-scatter baselines are regenerated, otherwise the oversized renders get baked in and have to be regenerated twice. `strict=False` means there's no race if a regenerated baseline lands before its marker is removed.

## Testing

Local (macOS): `298 passed, 7 xfailed, 0 failed` for `tests/test_plotting.py`; `tests/test_gpcca.py` plotting paths `32 passed`. pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)