### PR TITLE
Support pip install of PETSc/SLEPc; drop mpi4py from petsc extra

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,12 +26,42 @@ pip install "cellrank[moscot]"  # moscot for optimal transport (RealTimeKernel)
 pip install "cellrank[plot]"    # additional plotting dependencies
 ```
 
+### PETSc and SLEPc (faster large-scale solvers)
+
+For large datasets, CellRank uses [PETSc] and [SLEPc] (via [pyGPCCA]) to compute
+macrostates and fate probabilities faster and with less memory than the default
+[SciPy]-based eigensolver. Install them together with CellRank via the `petsc`
+extra:
+
+```bash
+pip install "cellrank[petsc]"
+```
+
+`petsc4py` and `slepc4py` ship no pre-built wheels, so pip compiles PETSc and
+SLEPc from source. CellRank only needs a serial build, which requires a **C
+compiler** — no Fortran or MPI. On systems without a Fortran compiler or system
+MPI (e.g. a stock macOS or minimal Linux), pass configuration options so the
+build stays C-only:
+
+```bash
+PETSC_CONFIGURE_OPTIONS="--with-fc=0 --with-mpi=0 --with-debugging=0 --with-shared-libraries=1" \
+    pip install "cellrank[petsc]"
+```
+
+Do **not** set `SLEPC_CONFIGURE_OPTIONS` — SLEPc inherits its configuration from
+the PETSc build. The build is a one-time compilation (a few minutes) and is then
+cached. If you would rather not compile from source, install PETSc and SLEPc via
+conda instead (see below). If you specifically need a distributed **MPI** build,
+install a system MPI and add `mpi4py` alongside the extra.
+
 ## conda / mamba / pixi
 
 CellRank is available on [conda-forge](https://anaconda.org/conda-forge/cellrank).
-This installation method is recommended if you need [PETSc] and [SLEPc],
-libraries for large-scale linear algebra that CellRank uses when computing
-macrostates or fate probabilities on large datasets:
+This installation method is convenient if you want **pre-built** [PETSc] and
+[SLEPc] — libraries for large-scale linear algebra that CellRank uses when
+computing macrostates or fate probabilities on large datasets — without
+compiling them from source (see the pip instructions above for the
+compile-from-source alternative):
 
 ```bash
 mamba install -c conda-forge cellrank
@@ -43,7 +73,7 @@ Or, using [pixi](https://pixi.sh/), a fast, modern conda replacement:
 pixi add cellrank
 ```
 
-To also install PETSc and SLEPc (conda-only packages):
+To also install PETSc and SLEPc as pre-built conda packages (no compilation):
 
 ```bash
 mamba install -c conda-forge cellrank petsc4py slepc4py
@@ -76,5 +106,6 @@ See {doc}`contributing` for setting up a full development environment.
 [issue]: https://github.com/theislab/cellrank/issues/new
 [PETSc]: https://petsc.org/
 [SLEPc]: https://slepc.upv.es/
+[pyGPCCA]: https://pygpcca.readthedocs.io/
 [SciPy]: https://scipy.org/
 [WSL]: https://learn.microsoft.com/windows/wsl/install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,12 @@ dependencies = [
 ]
 optional-dependencies.jax = [ "jax", "jaxlib" ]
 optional-dependencies.moscot = [ "moscot" ]
-optional-dependencies.petsc = [ "mpi4py", "petsc4py", "slepc4py" ]
+# petsc4py/slepc4py give pyGPCCA its fast `method='krylov'` solver for
+# macrostates and fate probabilities. mpi4py is intentionally omitted: pyGPCCA
+# runs serially, and requiring mpi4py forces a system-MPI build that breaks
+# `pip install cellrank[petsc]` on machines without MPI. See docs/installation.md
+# for installing a distributed MPI build.
+optional-dependencies.petsc = [ "petsc4py", "slepc4py" ]
 optional-dependencies.plot = [ "adjusttext" ]
 optional-dependencies.r = [ "rpy2>=3.3" ]
 optional-dependencies.scvelo = [ "scvelo>=0.3" ]


### PR DESCRIPTION
## Changes

* **Drop `mpi4py` from the `petsc` extra** (`optional-dependencies.petsc = [ "petsc4py", "slepc4py" ]`). pyGPCCA runs serially and never needs `mpi4py`; pinning it forced a system-MPI source build that made `pip install "cellrank[petsc]"` fail on any machine without a system MPI library (e.g. stock macOS, minimal Linux). Users who genuinely want a distributed MPI build can still install a system MPI and add `mpi4py` themselves.
* **Document the pip install path for PETSc/SLEPc** in `docs/installation.md`: a new "PETSc and SLEPc (faster large-scale solvers)" subsection covering `pip install "cellrank[petsc]"`, the from-source compilation caveat, and the C-only `PETSC_CONFIGURE_OPTIONS` recipe for systems without a Fortran/MPI toolchain.

## Bug fixes

* **Correct the inaccurate "conda-only" framing.** The docs previously called PETSc/SLEPc "conda-only packages" and implied conda was the only way to get them. They are pip-installable from PyPI sdists; the conda section is reframed as the *pre-built, no-compilation* option, cross-linked with the new pip instructions.

## Context

`petsc4py`/`slepc4py` enable pyGPCCA's fast `method='krylov'` solver for macrostates and fate probabilities. Without them, pyGPCCA falls back to `method='brandts'`, which densifies the transition matrix and emits warnings (`Unable to import petsc4py or slepc4py ...` / `Densifying`). conda ships prebuilt binaries, but pip-from-source is viable and only needs a C compiler — no Fortran or MPI — once `mpi4py` is out of the way.

### Verified

- `petsc` 3.25.2 + `slepc` 3.25.1 compile from PyPI sdists on macOS arm64 with a C compiler only, using `PETSC_CONFIGURE_OPTIONS="--with-fc=0 --with-mpi=0 --with-debugging=0 --with-shared-libraries=1"` (no Fortran, MPI, or system libs).
- `petsc4py`/`slepc4py` import and report versions.
- pyGPCCA `GPCCA(..., method='krylov').optimize()` runs under `warnings.simplefilter('error')` — i.e. the `brandts`/densify fallback is gone — **without** `mpi4py` installed.
- `cellrank[petsc]` resolves to `petsc`/`petsc4py`/`slepc`/`slepc4py` with no `mpi4py`.
- `pre-commit` passes on the changed files.

## Notes for reviewers

- The from-source build was validated on **macOS arm64**; the configure flags are platform-agnostic, but a Linux CI confirmation would be a nice follow-up. The Windows note in `installation.md` is intentionally unchanged (PETSc on Windows remains hard; WSL is still the recommendation).
- No `mpi4py` is bundled anymore — if any downstream tooling assumed `cellrank[petsc]` pulled in `mpi4py`, that is the one behavior change here.

## Related issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)