### PR TITLE
Fix Lineage.__repr__

### DIFF
--- a/src/cellrank/_utils/_lineage.py
+++ b/src/cellrank/_utils/_lineage.py
@@ -886,11 +886,6 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
         return LineageView(self)
 
     def __repr__(self) -> str:
-        # Format a plain ``ndarray`` view of the data rather than ``super().__repr__()``.
-        # Letting numpy format the ``Lineage`` directly makes it index single elements via
-        # ``self[i, j]``, which (because ``Lineage.__getitem__`` never returns a scalar)
-        # yields a ``(1, 1)`` ``Lineage``; converting that to a Python scalar raises
-        # ``TypeError`` on numpy >= 2.4 (it was only a ``DeprecationWarning`` before).
         prefix = f"{type(self).__name__}("
         body = np.array2string(np.asarray(self), separator=", ", prefix=prefix)
         return f"{prefix}{body},\n  names([{', '.join(self.names)}]))"

--- a/src/cellrank/_utils/_lineage.py
+++ b/src/cellrank/_utils/_lineage.py
@@ -886,10 +886,17 @@ class Lineage(np.ndarray, metaclass=LineageMeta):
         return LineageView(self)
 
     def __repr__(self) -> str:
-        return f"{super().__repr__()[:-1]},\n  names([{', '.join(self.names)}]))"
+        # Format a plain ``ndarray`` view of the data rather than ``super().__repr__()``.
+        # Letting numpy format the ``Lineage`` directly makes it index single elements via
+        # ``self[i, j]``, which (because ``Lineage.__getitem__`` never returns a scalar)
+        # yields a ``(1, 1)`` ``Lineage``; converting that to a Python scalar raises
+        # ``TypeError`` on numpy >= 2.4 (it was only a ``DeprecationWarning`` before).
+        prefix = f"{type(self).__name__}("
+        body = np.array2string(np.asarray(self), separator=", ", prefix=prefix)
+        return f"{prefix}{body},\n  names([{', '.join(self.names)}]))"
 
     def __str__(self):
-        return f"{super().__str__()}\n names=[{', '.join(self.names)}]"
+        return f"{np.array2string(np.asarray(self))}\n names=[{', '.join(self.names)}]"
 
     @property
     def _fmt(self) -> Callable[[Any], str]:


### PR DESCRIPTION
## Changes
<!-- Clearly and concisely describe your changesremove this section if this PR does not implement any changes -->

* Updated `Lineage.__repr__`

Now

```py
import numpy as np
from cellrank import Lineage

L = Lineage(
    np.array([[0.6, 0.4], [0.3, 0.7], [0.9, 0.1]]),
    names=["foo", "bar"],
    colors=["#ff0000", "#0000ff"],
)

print(L)
```

yields
```
[[0.6 0.4]
 [0.3 0.7]
 [0.9 0.1]]
 names=[foo, bar]
```
## Bug fixes
<!-- Clearly and concisely describe your bug fixes; remove this section if this PR does not implement any bug fixes -->

* Fixes #1365 